### PR TITLE
fix: use git version for snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ name: awspub
 summary: A tool to aid in the publication of aws images
 description: |
   A tool to aid in the publication of aws images
-version: test
+version: git
 base: core22
 confinement: strict
 


### PR DESCRIPTION
That way, the snap has a meaningful version for each new revision.