### PR TITLE
feat: add list command

### DIFF
--- a/awspub/cli/__init__.py
+++ b/awspub/cli/__init__.py
@@ -50,6 +50,19 @@ def _create(args) -> None:
     args.output.write((json.dumps({"images": images}, indent=4)))
 
 
+def _list(args) -> None:
+    """
+    List images based on the given configuration and write json
+    data to the given output
+    """
+    ctx = Context(args.config, args.config_mapping)
+    images: Dict[str, Dict[str, str]] = dict()
+    for image_name, image in _images_filtered(ctx, args.group):
+        res = image.list()
+        images[image_name] = res
+    args.output.write((json.dumps({"images": images}, indent=4)))
+
+
 def _verify(args) -> None:
     """
     Verify available images against configuration
@@ -95,6 +108,16 @@ def _parser():
     p_create.add_argument("--group", type=str, help="only handles images from given group")
     p_create.add_argument("config", type=pathlib.Path, help="the image configuration file path")
     p_create.set_defaults(func=_create)
+
+    # list
+    p_list = p_sub.add_parser("list", help="List images (but don't modify anything)")
+    p_list.add_argument(
+        "--output", type=argparse.FileType("w+"), help="output file path. defaults to stdout", default=sys.stdout
+    )
+    p_list.add_argument("--config-mapping", type=pathlib.Path, help="the image config template mapping file path")
+    p_list.add_argument("--group", type=str, help="only handles images from given group")
+    p_list.add_argument("config", type=pathlib.Path, help="the image configuration file path")
+    p_list.set_defaults(func=_list)
 
     # verify
     p_verify = p_sub.add_parser("verify", help="Verify images")

--- a/awspub/image.py
+++ b/awspub/image.py
@@ -245,6 +245,24 @@ class Image:
                     ec2client_region.deregister_image(ImageId=image_info.image_id)
                     logger.info(f"{self.image_name} in {region} ({image_info.image_id}) deleted")
 
+    def list(self) -> Dict[str, Optional[str]]:
+        """
+        Get image based on the available configuration
+        This doesn't change anything - it just tries to get the available image
+        for the different configured regions
+        :return: a Dict with region names as keys and optional image/AMI Ids as values
+        :rtype: Dict[str, Optional[str]]
+        """
+        image_ids: Dict[str, Optional[str]] = dict()
+        for region in self.image_regions:
+            ec2client_region: EC2Client = boto3.client("ec2", region_name=region)
+            image_info: Optional[_ImageInfo] = self._get(ec2client_region)
+            if image_info:
+                image_ids[region] = image_info.image_id
+            else:
+                image_ids[region] = None
+        return image_ids
+
     def create(self) -> Dict[str, str]:
         """
         Get or create a image based on the available configuration

--- a/awspub/tests/test_image.py
+++ b/awspub/tests/test_image.py
@@ -274,3 +274,24 @@ def test_image__tags(imagename, expected_tags):
     ctx = context.Context(curdir / "fixtures/config1.yaml", None)
     img = image.Image(ctx, imagename)
     assert img._tags == expected_tags
+
+
+@pytest.mark.parametrize(
+    "available_images,expected",
+    [
+        # image not available
+        ([{"Name": "test-image-6", "ImageId": "ami-123"}], {"eu-central-1": "ami-123"}),
+        # image available
+        ([], {"eu-central-1": None}),
+    ],
+)
+def test_image_list(available_images, expected):
+    """
+    Test the list for a given image
+    """
+    with patch("boto3.client") as bclient_mock:
+        instance = bclient_mock.return_value
+        instance.describe_images.return_value = {"Images": available_images}
+        ctx = context.Context(curdir / "fixtures/config1.yaml", None)
+        img = image.Image(ctx, "test-image-6")
+        assert img.list() == expected


### PR DESCRIPTION
The new "awspub list ..." command is useful to get a list of available images for the given configuration. The output is similar to the output of "awspub create ..." so this command can be used to get a list of available images.