### PR TITLE
feat: add IMDS support

### DIFF
--- a/awspub/configmodels.py
+++ b/awspub/configmodels.py
@@ -51,6 +51,7 @@ class ConfigImageModel(BaseModel):
     tpm_support: Optional[Literal["v2.0"]] = Field(
         description="Optional TPM support. If this is set, 'boot_mode' must be 'uefi'", default=None
     )
+    imds_support: Optional[Literal["v2.0"]] = Field(description="Optional IMDS support", default=None)
     share: Optional[List[str]] = Field(
         description="Optional list of account IDs the image and snapshot will be shared with", default=None
     )

--- a/awspub/image.py
+++ b/awspub/image.py
@@ -329,6 +329,9 @@ class Image:
                 if self.conf["tpm_support"]:
                     register_image_kwargs["TpmSupport"] = self.conf["tpm_support"]
 
+                if self.conf["imds_support"]:
+                    register_image_kwargs["ImdsSupport"] = self.conf["imds_support"]
+
                 if self.conf["uefi_data"]:
                     with open(self.conf["uefi_data"], "r") as f:
                         uefi_data = f.read()


### PR DESCRIPTION
The new image configuration option "imds_support" can be set for registering images wit imds support v2.0.