### PR TITLE
feat: add 2nd ephemeral block device

### DIFF
--- a/awspub/image.py
+++ b/awspub/image.py
@@ -407,7 +407,9 @@ class Image:
                             },
                             "DeviceName": self.conf["root_device_name"],
                         },
+                        # TODO: make those ephemeral block device mappings configurable
                         {"VirtualName": "ephemeral0", "DeviceName": "/dev/sdb"},
+                        {"VirtualName": "ephemeral1", "DeviceName": "/dev/sdc"},
                     ],
                     EnaSupport=True,
                     SriovNetSupport="simple",


### PR DESCRIPTION
AWS does provide instance store volumes. The amount of volumes (and volume sizes) depends on the different instance types (see [0]). For instance types with non-NVMe instance store volumes, the block device mapping must contain the wanted ephemeral block devices before instance launch.
Adding a second instance store volume is a sane default for now.

Refs:
- [0] https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html