### PR TITLE
fix: correctly set description for images

### DIFF
--- a/awspub/configmodels.py
+++ b/awspub/configmodels.py
@@ -87,7 +87,7 @@ class ConfigImageModel(BaseModel):
     Image/AMI configuration.
     """
 
-    desciption: Optional[str] = Field(description="Optional image description", default=None)
+    description: Optional[str] = Field(description="Optional image description", default=None)
     regions: Optional[List[str]] = Field(
         description="Optional list of regions for this image. If not given, all available regions will be used",
         default=None,


### PR DESCRIPTION
There was a typo in the configmodels.py so setting the image description didn't work.