### PR TITLE
test: enable type check during tox run

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 4
 # Choose your Python versions. They have to be available
 # on the system the tests are run on.
-envlist = py3,lint,docs
+envlist = py3,lint,docs,type
 isolated_build = true
 
 [testenv]


### PR DESCRIPTION
type checking via mypy should be done by default so add the type test to the default tox envlist.