### PR TITLE
fix: move website under canonical readthedocs

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -57,7 +57,7 @@ copyright = '%s CC-BY-SA, %s' % (datetime.date.today().year, author)
 # don't know yet)
 # NOTE: If no ogp_* variable is defined (e.g. if you remove this section) the
 # sphinxext.opengraph extension will be disabled.
-ogp_site_url = 'https://awspub.readthedocs.io/en/latest/'
+ogp_site_url = 'https://canonical-awspub.readthedocs-hosted.com/'
 # The documentation website name (usually the same as the product name)
 ogp_site_name = project
 # The URL of an image or logo that is used in the preview

--- a/readme.rst
+++ b/readme.rst
@@ -7,7 +7,7 @@ to AWS EC2.
 Documentation
 =============
 
-The documentation can be found under https://awspub.readthedocs.io/en/latest/ .
+The documentation can be found under https://canonical-awspub.readthedocs-hosted.com/ .
 
 Report issues
 =============

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,7 +14,7 @@ base: core22
 confinement: strict
 license: GPL-3.0
 issues: https://github.com/canonical/awspub/issues
-website: https://awspub.readthedocs.io/en/latest/
+website: https://canonical-awspub.readthedocs-hosted.com/
 
 plugs:
   dot-aws-config:


### PR DESCRIPTION
not sure if there is something else that needs to be done on the RTD side, but this needs to be done at a minimum