### PR TITLE
feat: parse sphinx requirements from poetry.lock

### DIFF
--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -14,3 +14,4 @@ jobs:
     uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yaml@main
     with:
       working-directory: '.'
+      python-version: '3.12'

--- a/.github/workflows/sphinx-python-dependency-build-checks.yml
+++ b/.github/workflows/sphinx-python-dependency-build-checks.yml
@@ -24,6 +24,8 @@ jobs:
   build:
     name: build
     runs-on: ubuntu-latest
+    with:
+      python-version: '3.12'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/conf.py
+++ b/conf.py
@@ -99,6 +99,7 @@ exclude_patterns = [
     'Thumbs.db',
     '.DS_Store',
     '.sphinx',
+    '.tox'
 ]
 exclude_patterns.extend(custom_excludes)
 

--- a/custom_conf.py
+++ b/custom_conf.py
@@ -1,4 +1,5 @@
 import datetime
+from requirements_parser import _get_requirements
 
 # Custom configuration for the Sphinx documentation builder.
 # All configuration specific to your project should be done in this file.
@@ -189,15 +190,8 @@ custom_extensions = [
 custom_required_modules = [
     "autodoc_pydantic",
     "pydantic-settings",
-    # package deps
-    "boto3",
-    "botocore",
-    "ruamel.yaml",
-    "mypy_boto3_s3",
-    "mypy_boto3_ssm",
-    "mypy_boto3_ec2",
-    "mypy_boto3_marketplace_catalog",
 ]
+custom_required_modules.extend(_get_requirements())
 
 # Add files or directories that should be excluded from processing.
 custom_excludes = [

--- a/requirements_parser.py
+++ b/requirements_parser.py
@@ -1,0 +1,20 @@
+import tomllib
+
+LOCK = 'poetry.lock'
+
+
+def _get_requirements() -> list[str]:
+    c = _read_config()
+
+    deps = set()
+
+    for dep in c["package"]:
+        deps.add(dep['name'])
+
+    return list(deps)
+
+
+def _read_config() -> dict:
+    with open(LOCK, 'rb') as f:
+        config = tomllib.load(f)
+    return config

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands =
 
 [flake8]
 show-source = True
-exclude = .venv,.tox,dist,doc,build,*.egg,node_modules,.sphinx,custom_conf.py,conf.py
+exclude = .venv,.tox,dist,doc,build,*.egg,node_modules,.sphinx,custom_conf.py,conf.py,tomllib
 max-line-length = 120
 
 [testenv:venv]


### PR DESCRIPTION
This changes how custom_required_modules is set to pull values directly from poetry.lock. This results in an inflated requirements list, but ensures that future requirements are automatically included.