### PR TITLE
feat: remove bucket_region from config

### DIFF
--- a/awspub/configmodels.py
+++ b/awspub/configmodels.py
@@ -14,7 +14,6 @@ class ConfigS3Model(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     bucket_name: str = Field(description="The S3 bucket name")
-    bucket_region: str = Field(description="The S3 region name")
 
 
 class ConfigSourceModel(BaseModel):

--- a/awspub/exceptions.py
+++ b/awspub/exceptions.py
@@ -8,3 +8,9 @@ class MultipleImportSnapshotTasksException(Exception):
 
 class MultipleImagesException(Exception):
     pass
+
+
+class BucketDoesNotExistException(Exception):
+    def __init__(self, bucket_name: str, *args, **kwargs):
+        msg = f"The bucket named '{bucket_name}' does not exist. You will need to create the bucket before proceeding."
+        super().__init__(msg, *args, **kwargs)

--- a/awspub/tests/fixtures/config-invalid-s3-extra.yaml
+++ b/awspub/tests/fixtures/config-invalid-s3-extra.yaml
@@ -1,7 +1,6 @@
 awspub:
   s3:
     bucket_name: "bucket1"
-    bucket_region: "us-east-1"
     invalid_field: "not allowed" # This is an invalid field
   source:
     path: "config1.vmdk"

--- a/awspub/tests/fixtures/config-minimal.yaml
+++ b/awspub/tests/fixtures/config-minimal.yaml
@@ -6,7 +6,6 @@ awspub:
 
   s3:
     bucket_name: "bucket1"
-    bucket_region: "eu-central-2"
 
   images:
     "my-custom-image":

--- a/awspub/tests/fixtures/config-valid-nonawspub.yaml
+++ b/awspub/tests/fixtures/config-valid-nonawspub.yaml
@@ -1,7 +1,6 @@
 awspub:
   s3:
     bucket_name: "bucket1"
-    bucket_region: "us-east-1"
   source:
     path: "config1.vmdk"
     architecture: "x86_64"

--- a/awspub/tests/fixtures/config1.yaml
+++ b/awspub/tests/fixtures/config1.yaml
@@ -1,7 +1,6 @@
 awspub:
   s3:
     bucket_name: "bucket1"
-    bucket_region: "region1"
 
   source:
     # config1.vmdk generated with

--- a/awspub/tests/fixtures/config2.yaml
+++ b/awspub/tests/fixtures/config2.yaml
@@ -1,7 +1,6 @@
 awspub:
   s3:
     bucket_name: "bucket1"
-    bucket_region: "region1"
 
   source:
     # config1.vmdk generated with

--- a/awspub/tests/fixtures/config3-duplicate-keys.yaml
+++ b/awspub/tests/fixtures/config3-duplicate-keys.yaml
@@ -1,7 +1,6 @@
 awspub:
   s3:
     bucket_name: "bucket1"
-    bucket_region: "region1"
 
   source:
     path: "config1.vmdk"

--- a/awspub/tests/test_context.py
+++ b/awspub/tests/test_context.py
@@ -20,7 +20,6 @@ def test_context_create():
     assert ctx.source_sha256 == "6252475408b9f9ee64452b611d706a078831a99b123db69d144d878a0488a0a8"
     assert ctx.conf["source"]["architecture"] == "x86_64"
     assert ctx.conf["s3"]["bucket_name"] == "bucket1"
-    assert ctx.conf["s3"]["bucket_region"] == "region1"
 
 
 def test_context_create_minimal():
@@ -32,7 +31,6 @@ def test_context_create_minimal():
     assert ctx.source_sha256 == "6252475408b9f9ee64452b611d706a078831a99b123db69d144d878a0488a0a8"
     assert ctx.conf["source"]["architecture"] == "x86_64"
     assert ctx.conf["s3"]["bucket_name"] == "bucket1"
-    assert ctx.conf["s3"]["bucket_region"] == "eu-central-2"
 
 
 def test_context_create_with_mapping():

--- a/awspub/tests/test_image.py
+++ b/awspub/tests/test_image.py
@@ -48,7 +48,8 @@ def test_snapshot_names(imagename, snapshotname):
         ("test-image-2", ["all-region-1", "all-region-2"]),
     ],
 )
-def test_image_regions(imagename, regions):
+@patch("awspub.s3.S3.bucket_region", return_value="region1")
+def test_image_regions(s3_region_mock, imagename, regions):
     """
     Test the regions for a given image
     """
@@ -299,7 +300,8 @@ def test_image_list(available_images, expected):
         assert img.list() == expected
 
 
-def test_image_create_existing():
+@patch("awspub.s3.S3.bucket_region", return_value="region1")
+def test_image_create_existing(s3_bucket_mock):
     """
     Test the create() method for a given image that already exist
     """

--- a/awspub/tests/test_s3.py
+++ b/awspub/tests/test_s3.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from awspub import context, s3
+from awspub.exceptions import BucketDoesNotExistException
 
 curdir = pathlib.Path(__file__).parent.resolve()
 
@@ -49,3 +50,25 @@ def test_s3__get_multipart_upload_id(list_multipart_uploads_resp, create_multipa
         sthree = s3.S3(ctx)
         sthree._get_multipart_upload_id()
         assert instance.create_multipart_upload.called == create_multipart_upload_called
+
+
+@patch("awspub.s3.S3._bucket_exists", return_value=True)
+@patch("awspub.s3.boto3")
+def test_s3_bucket_region_bucket_exists(boto3_mock, bucket_exists_mock):
+    region_name = "sample-region-1"
+    head_bucket = {"BucketRegion": region_name}
+    boto3_mock.client.return_value.head_bucket.return_value = head_bucket
+    ctx = context.Context(curdir / "fixtures/config1.yaml", None)
+    sthree = s3.S3(ctx)
+
+    assert sthree.bucket_region == region_name
+
+
+@patch("awspub.s3.S3._bucket_exists", return_value=False)
+@patch("boto3.client")
+def test_s3_bucket_region_bucket_not_exists(bclient_mock, bucket_exists_mock):
+    ctx = context.Context(curdir / "fixtures/config1.yaml", None)
+    sthree = s3.S3(ctx)
+
+    with pytest.raises(BucketDoesNotExistException):
+        sthree.bucket_region()

--- a/docs/config-samples/config-minimal-groups.yaml
+++ b/docs/config-samples/config-minimal-groups.yaml
@@ -4,7 +4,6 @@ awspub:
     architecture: "arm64"
   s3:
     bucket_name: "awspub-toabctl"
-    bucket_region: "eu-central-1"
   images:
     "my-custom-image-1":
       boot_mode: "uefi-preferred"

--- a/docs/config-samples/config-minimal-image-tags.yaml
+++ b/docs/config-samples/config-minimal-image-tags.yaml
@@ -4,7 +4,6 @@ awspub:
     architecture: "x86_64"
   s3:
     bucket_name: "awspub-toabctl"
-    bucket_region: "eu-central-1"
   images:
     "my-custom-image-1":
       boot_mode: "uefi-preferred"

--- a/docs/config-samples/config-minimal-marketplace.yaml
+++ b/docs/config-samples/config-minimal-marketplace.yaml
@@ -4,7 +4,6 @@ awspub:
     architecture: "x86_64"
   s3:
     bucket_name: "awspub-toabctl"
-    bucket_region: "us-east-1"
   images:
     "my-custom-image":
       boot_mode: "uefi-preferred"

--- a/docs/config-samples/config-minimal-public.yaml
+++ b/docs/config-samples/config-minimal-public.yaml
@@ -4,7 +4,6 @@ awspub:
     architecture: "x86_64"
   s3:
     bucket_name: "awspub-toabctl"
-    bucket_region: "eu-central-1"
   images:
     "my-custom-image":
       boot_mode: "uefi-preferred"

--- a/docs/config-samples/config-minimal-ssm.yaml
+++ b/docs/config-samples/config-minimal-ssm.yaml
@@ -4,7 +4,6 @@ awspub:
     architecture: "x86_64"
   s3:
     bucket_name: "awspub-toabctl"
-    bucket_region: "eu-central-1"
   images:
     "my-custom-image":
       boot_mode: "uefi-preferred"

--- a/docs/config-samples/config-minimal-tags.yaml
+++ b/docs/config-samples/config-minimal-tags.yaml
@@ -4,7 +4,6 @@ awspub:
     architecture: "x86_64"
   s3:
     bucket_name: "awspub-toabctl"
-    bucket_region: "eu-central-1"
   images:
     "my-custom-image":
       boot_mode: "uefi-preferred"

--- a/docs/config-samples/config-minimal.yaml
+++ b/docs/config-samples/config-minimal.yaml
@@ -4,7 +4,6 @@ awspub:
     architecture: "x86_64"
   s3:
     bucket_name: "awspub-toabctl"
-    bucket_region: "eu-central-1"
   images:
     "my-custom-image":
       boot_mode: "uefi-preferred"

--- a/docs/config-samples/config-multiple-images.yaml
+++ b/docs/config-samples/config-multiple-images.yaml
@@ -6,7 +6,6 @@ awspub:
 
   s3:
     bucket_name: "awspub-toabctl"
-    bucket_region: "eu-central-1"
 
   images:
     "my-custom-image":

--- a/docs/config-samples/config-with-parameters.yaml
+++ b/docs/config-samples/config-with-parameters.yaml
@@ -4,7 +4,6 @@ awspub:
     architecture: "x86_64"
   s3:
     bucket_name: "awspub-toabctl"
-    bucket_region: "eu-central-1"
   images:
     "my-custom-image-$serial":
       boot_mode: "uefi-preferred"


### PR DESCRIPTION
specifying bucket_region in config makes sharing a single config across aws partitions challenging, and also introduces the possibility of specifying a bucket_name that exists outside of the bucket_region. Instead of requiring users to specify the region, we instead just take the bucket name (which is unique across all regions of a partition) and, if the bucket exists, query aws for the region it is in. If the bucket does not exist, raise an error indicating same.