### PR TITLE
feat(snap): build only for amd64 and arm64

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,6 +15,9 @@ confinement: strict
 license: GPL-3.0
 issues: https://github.com/canonical/awspub/issues
 website: https://canonical-awspub.readthedocs-hosted.com/
+architectures:
+  - build-on: [amd64]
+  - build-on: [arm64]
 
 plugs:
   dot-aws-config:


### PR DESCRIPTION
Those are the usually used architectures and those 2 architectures are also available on EC2. So only build for those 2.