### PR TITLE
feat: apply marketplace configuration only in default aws partition

### DIFF
--- a/awspub/configmodels.py
+++ b/awspub/configmodels.py
@@ -131,7 +131,9 @@ class ConfigImageModel(BaseModel):
         description="Optional boolean field indicates if the image should be public", default=False
     )
     marketplace: Optional[ConfigImageMarketplaceModel] = Field(
-        description="Optional structure containing Marketplace related configuration", default=None
+        description="Optional structure containing Marketplace related configuration for the commercial "
+        "'aws' partition",
+        default=None,
     )
     ssm_parameter: Optional[List[ConfigImageSSMParameterModel]] = Field(
         description="Optional list of SSM parameter paths of type `aws:ec2:image` which will "

--- a/awspub/tests/test_image.py
+++ b/awspub/tests/test_image.py
@@ -118,19 +118,23 @@ def test_image___get_root_device_snapshot_id(root_device_name, block_device_mapp
 
 
 @pytest.mark.parametrize(
-    "imagename,called_mod_image,called_mod_snapshot,called_start_change_set,called_put_parameter",
+    "imagename,partition,called_mod_image,called_mod_snapshot,called_start_change_set,called_put_parameter",
     [
-        ("test-image-6", True, True, False, False),
-        ("test-image-7", False, False, False, False),
-        ("test-image-8", True, True, True, True),
+        ("test-image-6", "aws", True, True, False, False),
+        ("test-image-7", "aws", False, False, False, False),
+        ("test-image-8", "aws", True, True, True, True),
+        ("test-image-8", "aws-cn", True, True, False, True),
     ],
 )
-def test_image_public(imagename, called_mod_image, called_mod_snapshot, called_start_change_set, called_put_parameter):
+def test_image_public(
+    imagename, partition, called_mod_image, called_mod_snapshot, called_start_change_set, called_put_parameter
+):
     """
     Test the public() for a given image
     """
     with patch("boto3.client") as bclient_mock:
         instance = bclient_mock.return_value
+        instance.meta.partition = partition
         instance.describe_images.return_value = {
             "Images": [
                 {


### PR DESCRIPTION
If awspub configuration files are used in different partitions than the default (aws) one, it doesn't make sense (and doesn't work) to try to create a Marketplace version update. So make it clear that the marketplace configuration only applies in the default partition. Note: there is also a china marketplace but that's for now not supported.