### PR TITLE
fix: Add bucket_region attribute in ConfigS3Model class

### DIFF
--- a/awspub/configmodels.py
+++ b/awspub/configmodels.py
@@ -14,6 +14,7 @@ class ConfigS3Model(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     bucket_name: str = Field(description="The S3 bucket name")
+    bucket_region: str = Field(description="Region where S3 bucekt will be created")
 
 
 class ConfigSourceModel(BaseModel):

--- a/awspub/tests/fixtures/config-invalid-s3-extra.yaml
+++ b/awspub/tests/fixtures/config-invalid-s3-extra.yaml
@@ -1,6 +1,7 @@
 awspub:
   s3:
     bucket_name: "bucket1"
+    bucket_region: "us-east-1"
     invalid_field: "not allowed" # This is an invalid field
   source:
     path: "config1.vmdk"

--- a/awspub/tests/fixtures/config-minimal.yaml
+++ b/awspub/tests/fixtures/config-minimal.yaml
@@ -6,6 +6,7 @@ awspub:
 
   s3:
     bucket_name: "bucket1"
+    bucket_region: "us-east-1"
 
   images:
     "my-custom-image":

--- a/awspub/tests/fixtures/config-valid-nonawspub.yaml
+++ b/awspub/tests/fixtures/config-valid-nonawspub.yaml
@@ -1,6 +1,7 @@
 awspub:
   s3:
     bucket_name: "bucket1"
+    bucket_region: "us-east-1"
   source:
     path: "config1.vmdk"
     architecture: "x86_64"

--- a/awspub/tests/fixtures/config1.yaml
+++ b/awspub/tests/fixtures/config1.yaml
@@ -1,6 +1,7 @@
 awspub:
   s3:
     bucket_name: "bucket1"
+    bucket_region: "us-east-1"
 
   source:
     # config1.vmdk generated with

--- a/awspub/tests/fixtures/config2.yaml
+++ b/awspub/tests/fixtures/config2.yaml
@@ -1,6 +1,7 @@
 awspub:
   s3:
     bucket_name: "bucket1"
+    bucket_region: "us-east-1"
 
   source:
     # config1.vmdk generated with

--- a/awspub/tests/fixtures/config3-duplicate-keys.yaml
+++ b/awspub/tests/fixtures/config3-duplicate-keys.yaml
@@ -1,6 +1,7 @@
 awspub:
   s3:
     bucket_name: "bucket1"
+    bucket_region: "us-east-1"
 
   source:
     path: "config1.vmdk"

--- a/docs/config-samples/config-minimal-groups.yaml
+++ b/docs/config-samples/config-minimal-groups.yaml
@@ -4,6 +4,7 @@ awspub:
     architecture: "arm64"
   s3:
     bucket_name: "awspub-toabctl"
+    bucket_region: "us-east-1"
   images:
     "my-custom-image-1":
       boot_mode: "uefi-preferred"

--- a/docs/config-samples/config-minimal-image-tags.yaml
+++ b/docs/config-samples/config-minimal-image-tags.yaml
@@ -4,6 +4,7 @@ awspub:
     architecture: "x86_64"
   s3:
     bucket_name: "awspub-toabctl"
+    bucket_region: "us-east-1"
   images:
     "my-custom-image-1":
       boot_mode: "uefi-preferred"

--- a/docs/config-samples/config-minimal-marketplace.yaml
+++ b/docs/config-samples/config-minimal-marketplace.yaml
@@ -4,6 +4,7 @@ awspub:
     architecture: "x86_64"
   s3:
     bucket_name: "awspub-toabctl"
+    bucket_region: "us-east-1"
   images:
     "my-custom-image":
       boot_mode: "uefi-preferred"

--- a/docs/config-samples/config-minimal-public.yaml
+++ b/docs/config-samples/config-minimal-public.yaml
@@ -4,6 +4,7 @@ awspub:
     architecture: "x86_64"
   s3:
     bucket_name: "awspub-toabctl"
+    bucket_region: "us-east-1"
   images:
     "my-custom-image":
       boot_mode: "uefi-preferred"

--- a/docs/config-samples/config-minimal-ssm.yaml
+++ b/docs/config-samples/config-minimal-ssm.yaml
@@ -4,6 +4,7 @@ awspub:
     architecture: "x86_64"
   s3:
     bucket_name: "awspub-toabctl"
+    bucket_region: "us-east-1"
   images:
     "my-custom-image":
       boot_mode: "uefi-preferred"

--- a/docs/config-samples/config-minimal-tags.yaml
+++ b/docs/config-samples/config-minimal-tags.yaml
@@ -4,6 +4,7 @@ awspub:
     architecture: "x86_64"
   s3:
     bucket_name: "awspub-toabctl"
+    bucket_region: "us-east-1"
   images:
     "my-custom-image":
       boot_mode: "uefi-preferred"

--- a/docs/config-samples/config-minimal.yaml
+++ b/docs/config-samples/config-minimal.yaml
@@ -4,6 +4,7 @@ awspub:
     architecture: "x86_64"
   s3:
     bucket_name: "awspub-toabctl"
+    bucket_region: "us-east-1"
   images:
     "my-custom-image":
       boot_mode: "uefi-preferred"

--- a/docs/config-samples/config-multiple-images.yaml
+++ b/docs/config-samples/config-multiple-images.yaml
@@ -6,6 +6,7 @@ awspub:
 
   s3:
     bucket_name: "awspub-toabctl"
+    bucket_region: "us-east-1"
 
   images:
     "my-custom-image":

--- a/docs/config-samples/config-with-parameters.yaml
+++ b/docs/config-samples/config-with-parameters.yaml
@@ -4,6 +4,7 @@ awspub:
     architecture: "x86_64"
   s3:
     bucket_name: "awspub-toabctl"
+    bucket_region: "us-east-1"
   images:
     "my-custom-image-$serial":
       boot_mode: "uefi-preferred"


### PR DESCRIPTION
`bucket_region` has been missing in ConfigS3Model class and pydantic raises error since it detected this as an extra fields.