### PR TITLE
feat: use version from git

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "awspub"
-version = "0.1.0"
+version = "0.0.0"
 description = "Publish images to AWS EC2"
 
 license = "GPL-3.0-or-later"
@@ -56,3 +56,7 @@ autodoc_pydantic = "*"
 
 [tool.poetry.scripts]
 awspub = "awspub.cli:main"
+
+[tool.poetry-dynamic-versioning]
+enable = true
+vcs = 'git'


### PR DESCRIPTION
Instead of hardcoding a version in pyproject.toml, use a poetry plugin to get the version from git. That makes release versioning easier.