### PR TITLE
feat: wait up to 45 min for snapshot_complete

### DIFF
--- a/awspub/snapshot.py
+++ b/awspub/snapshot.py
@@ -236,6 +236,6 @@ class Snapshot:
             ec2client_dest = boto3.client("ec2", region_name=destination_region)
             waiter = ec2client_dest.get_waiter("snapshot_completed")
             logger.info(f"Waiting for {snapshot_id} in {ec2client_dest.meta.region_name} to complete ...")
-            waiter.wait(SnapshotIds=[snapshot_id], WaiterConfig={"Delay": 30, "MaxAttempts": 60})
+            waiter.wait(SnapshotIds=[snapshot_id], WaiterConfig={"Delay": 30, "MaxAttempts": 90})
 
         return snapshot_ids


### PR DESCRIPTION
There are sometimes errors while waiting for 30 min for a snapshot to complete. This hopefully helps with:

2024-09-30 23:39:18,921:awspub.snapshot:INFO:Waiting for snap-0d10ebf6308edec1b in ap-south-2 to complete ... Traceback (most recent call last):
  File "/snap/awspub/156/bin/awspub", line 8, in <module>
    sys.exit(main())
  File "/snap/awspub/156/lib/python3.10/site-packages/awspub/cli/__init__.py", line 200, in main
    args.func(args)
  File "/snap/awspub/156/lib/python3.10/site-packages/awspub/cli/__init__.py", line 66, in _create
    image_result: Dict[str, _ImageInfo] = image.create()
  File "/snap/awspub/156/lib/python3.10/site-packages/awspub/image.py", line 388, in create
    snapshot_ids: Dict[str, str] = self._snapshot.copy(
  File "/snap/awspub/156/lib/python3.10/site-packages/awspub/snapshot.py", line 239, in copy
    waiter.wait(SnapshotIds=[snapshot_id], WaiterConfig={"Delay": 30, "MaxAttempts": 60})
  File "/snap/awspub/156/lib/python3.10/site-packages/botocore/waiter.py", line 55, in wait
    Waiter.wait(self, **kwargs)
  File "/snap/awspub/156/lib/python3.10/site-packages/botocore/waiter.py", line 387, in wait
    raise WaiterError(
botocore.exceptions.WaiterError: Waiter SnapshotCompleted failed: Max attempts exceeded