### PR TITLE
ci: enable python 3.8 testing

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.10", "3.11", "3.12"]
+        python: ["3.8", "3.10", "3.11", "3.12"]
     steps:
       - name: Setup Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
Ubuntu Focal has python 3.8 so do test that version, too.