### PR TITLE
ci: correct an error in a GitHub workflow

### DIFF
--- a/.github/workflows/sphinx-python-dependency-build-checks.yml
+++ b/.github/workflows/sphinx-python-dependency-build-checks.yml
@@ -24,11 +24,15 @@ jobs:
   build:
     name: build
     runs-on: ubuntu-latest
-    with:
-      python-version: '3.12'
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
This takes care of the `[canonical/awspub] Run failed at startup: Check and document build requirements for Sphinx venv` error that was occurring. 