### PR TITLE
fix: do not attempt to share image with empty list

### DIFF
--- a/awspub/image.py
+++ b/awspub/image.py
@@ -189,6 +189,10 @@ class Image:
         """
         share_list = self._share_list_filtered(share_conf)
 
+        if not share_list:
+            logger.info("no valid accounts found for sharing in this partition, skipping")
+            return
+
         for region, image_info in images.items():
             ec2client: EC2Client = boto3.client("ec2", region_name=region)
             # modify image permissions


### PR DESCRIPTION
Check for empty list and bail on sharing if no accounts found in partition.
In cases where partition filtering removes all possible accounts from a share list, attempting to share with an empty list will cause a InvalidParameterCombination error to be raised.