### PR TITLE
docs: move release management into its own docs

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -197,7 +197,8 @@ custom_required_modules.extend(_get_requirements())
 custom_excludes = [
     'doc-cheat-sheet*',
     '.github',
-    'readme.rst'
+    'readme.rst',
+    'release-management.rst',
     ]
 
 # Add CSS files (located in .sphinx/_static/)

--- a/readme.rst
+++ b/readme.rst
@@ -19,20 +19,3 @@ License
 =======
 
 The project uses `GPL-3.0` as license.
-
-Doing a new release
-===================
-
-New releases are mostly automated.
-
-pypi
-----
-
-For a new release on pypi, create a new tag (following semantic versioning)
-with a `v` as prefix (eg. `v0.2.1`).
-
-snapstore
----------
-
-The latest git commit will be automatically build and published to the `latest/edge`
-channel. Manually promote from `latest/edge` to `latest/stable`.

--- a/release-management.rst
+++ b/release-management.rst
@@ -1,0 +1,26 @@
+Doing a new release
+===================
+
+New releases are mostly automated. A new github release (which includes
+creating a new git tag) can be done via the `github web UI <new-release>`_.
+In `Choose a tag`, create the new one (with a `v` as prefix, so eg. `v0.1.1`)
+and as a `Release title`, use the same name as the tag (so eg. `v0.1.1`).
+
+pypi
+----
+
+New releases on pypi happen automatically when a new git tag gets
+created. The tag needs to be prefixed with `v` (eg. `v0.10.0`).
+
+snapstore
+---------
+
+The latest git commit will be automatically build and published to the `latest/edge`
+channel. Promoting to `latest/stable` can be done with:
+
+.. code-block::
+
+   snapcraft promote --from-channel latest/edge --to-channel latest/stable awspub
+
+
+.. _new-release: https://github.com/canonical/awspub/releases/new


### PR DESCRIPTION
That's not useful for end-users so have a separate docs for explaining how to do new releases.