### PR TITLE
fix: Allow SNS config has separate list of regions

### DIFF
--- a/awspub/common.py
+++ b/awspub/common.py
@@ -1,4 +1,10 @@
-from typing import Tuple
+import logging
+from typing import List, Tuple
+
+import boto3
+from mypy_boto3_ec2.client import EC2Client
+
+logger = logging.getLogger(__name__)
 
 
 def _split_partition(val: str) -> Tuple[str, str]:
@@ -16,3 +22,43 @@ def _split_partition(val: str) -> Tuple[str, str]:
         partition = "aws"
         resource = val
     return partition, resource
+
+
+def _get_regions(region_to_query: str, regions_allowlist: List[str]) -> List[str]:
+    """
+    Get a list of region names querying the `region_to_query` for all regions and
+    then filtering by `regions_allowlist`.
+    If no `regions_allowlist` is given, all queried regions are returned for the
+    current partition.
+    If `regions_allowlist` is given, all regions from that list are returned if
+    the listed region exist in the current partition.
+    Eg. `us-east-1` listed in `regions_allowlist` won't be returned if the current
+    partition is `aws-cn`.
+    :param region_to_query: region name of current partition
+    :type region_to_query: str
+    :praram regions_allowlist: list of regions in config file
+    :type regions_allowlist: List[str]
+    :return: list of regions names
+    :rtype: List[str]
+    """
+
+    # get all available regions
+    ec2client: EC2Client = boto3.client("ec2", region_name=region_to_query)
+    resp = ec2client.describe_regions()
+    ec2_regions_all = [r["RegionName"] for r in resp["Regions"]]
+
+    if regions_allowlist:
+        # filter out regions that are not available in the current partition
+        regions_allowlist_set = set(regions_allowlist)
+        ec2_regions_all_set = set(ec2_regions_all)
+        regions = list(regions_allowlist_set.intersection(ec2_regions_all_set))
+        diff = regions_allowlist_set.difference(ec2_regions_all_set)
+        if diff:
+            logger.warning(
+                f"regions {diff} listed in regions allowlist are not available in the current partition."
+                " Ignoring those."
+            )
+    else:
+        regions = ec2_regions_all
+
+    return regions

--- a/awspub/configmodels.py
+++ b/awspub/configmodels.py
@@ -112,6 +112,12 @@ class ConfigImageSNSNotificationModel(BaseModel):
         description="The body of the message to be sent to subscribers.",
         default={SNSNotificationProtocol.DEFAULT: ""},
     )
+    regions: Optional[List[str]] = Field(
+        description="Optional list of regions for sending notification. If not given, regions where the image "
+        "registered will be used from the currently used parition. If a region doesn't exist in the currently "
+        "used partition, it will be ignored.",
+        default=None,
+    )
 
     @field_validator("message")
     def check_message(cls, value):

--- a/awspub/image.py
+++ b/awspub/image.py
@@ -342,15 +342,7 @@ class Image:
         Publish SNS notifiations about newly available images to subscribers
         """
 
-        # Checking if the image(s) are registered or published before sending the notification
-        for region in self.image_regions:
-            ec2client_region: EC2Client = boto3.client("ec2", region_name=region)
-            image_info: Optional[_ImageInfo] = self._get(ec2client_region)
-            if not image_info:
-                logger.error(f"can not send SNS notification for {self.image_name} because no image found in {region}")
-                return
-
-        SNSNotification(self._ctx, self.image_name, self._s3.bucket_region).publish()
+        SNSNotification(self._ctx, self.image_name).publish()
 
     def cleanup(self) -> None:
         """

--- a/awspub/image.py
+++ b/awspub/image.py
@@ -9,7 +9,7 @@ from mypy_boto3_ec2.client import EC2Client
 from mypy_boto3_ssm import SSMClient
 
 from awspub import exceptions
-from awspub.common import _split_partition
+from awspub.common import _get_regions, _split_partition
 from awspub.context import Context
 from awspub.image_marketplace import ImageMarketplace
 from awspub.s3 import S3
@@ -121,28 +121,11 @@ class Image:
     @property
     def image_regions(self) -> List[str]:
         """
-        Get the image regions. Either configured in the image configuration
-        or all available regions.
-        If a region is listed that is not available in the currently used partition,
-        that region will be ignored (eg. having us-east-1 configured but running in the aws-cn
-        partition doesn't include us-east-1 here).
+        Get the image regions.
         """
         if not self._image_regions_cached:
-            # get all available regions
-            ec2client: EC2Client = boto3.client("ec2", region_name=self._s3.bucket_region)
-            resp = ec2client.describe_regions()
-            image_regions_all = [r["RegionName"] for r in resp["Regions"]]
-
-            if self.conf["regions"]:
-                # filter out regions that are not available in the current partition
-                image_regions_configured_set = set(self.conf["regions"])
-                image_regions_all_set = set(image_regions_all)
-                self._image_regions = list(image_regions_configured_set.intersection(image_regions_all_set))
-                diff = image_regions_configured_set.difference(image_regions_all_set)
-                if diff:
-                    logger.warning(f"configured regions {diff} not available in the current partition. Ignoring those.")
-            else:
-                self._image_regions = image_regions_all
+            regions_configured = self.conf["regions"] if "regions" in self.conf else []
+            self._image_regions = _get_regions(self._s3.bucket_region, regions_configured)
             self._image_regions_cached = True
         return self._image_regions
 
@@ -358,14 +341,16 @@ class Image:
         """
         Publish SNS notifiations about newly available images to subscribers
         """
+
+        # Checking if the image(s) are registered or published before sending the notification
         for region in self.image_regions:
             ec2client_region: EC2Client = boto3.client("ec2", region_name=region)
             image_info: Optional[_ImageInfo] = self._get(ec2client_region)
-
             if not image_info:
                 logger.error(f"can not send SNS notification for {self.image_name} because no image found in {region}")
                 return
-            SNSNotification(self._ctx, self.image_name, region).publish()
+
+        SNSNotification(self._ctx, self.image_name, self._s3.bucket_region).publish()
 
     def cleanup(self) -> None:
         """

--- a/awspub/sns.py
+++ b/awspub/sns.py
@@ -11,8 +11,10 @@ from botocore.exceptions import ClientError
 from mypy_boto3_sns.client import SNSClient
 from mypy_boto3_sts.client import STSClient
 
+from awspub.common import _get_regions
 from awspub.context import Context
 from awspub.exceptions import AWSAuthorizationException, AWSNotificationException
+from awspub.s3 import S3
 
 logger = logging.getLogger(__name__)
 
@@ -23,13 +25,13 @@ class SNSNotification(object):
     structuring rules for SNS notification JSON
     """
 
-    def __init__(self, context: Context, image_name: str, region_name: str):
+    def __init__(self, context: Context, image_name: str):
         """
         Construct a message and verify that it is valid
         """
         self._ctx: Context = context
         self._image_name: str = image_name
-        self._region_name: str = region_name
+        self._s3: S3 = S3(context)
 
     @property
     def conf(self) -> List[Dict[str, Any]]:
@@ -39,6 +41,20 @@ class SNSNotification(object):
         return self._ctx.conf["images"][self._image_name]["sns"]
 
     def _get_topic_arn(self, topic_name: str) -> str:
+    def _sns_regions(self, topic_config: Dict[Any, Any]) -> List[str]:
+        """
+        Get the sns regions. Either configured in the sns configuration
+        or all available regions.
+        If a region is listed that is not available in the currently used partition,
+        that region will be ignored (eg. having us-east-1 configured but running in the aws-cn
+        partition doesn't include us-east-1 here).
+        """
+
+        regions_configured = topic_config["regions"] if "regions" in topic_config else []
+        sns_regions = _get_regions(self._s3.bucket_region, regions_configured)
+
+        return sns_regions
+
         """
         Calculate topic ARN based on partition, region, account and topic name
         :param topic_name: Name of topic

--- a/awspub/sns.py
+++ b/awspub/sns.py
@@ -40,7 +40,6 @@ class SNSNotification(object):
         """
         return self._ctx.conf["images"][self._image_name]["sns"]
 
-    def _get_topic_arn(self, topic_name: str) -> str:
     def _sns_regions(self, topic_config: Dict[Any, Any]) -> List[str]:
         """
         Get the sns regions. Either configured in the sns configuration
@@ -55,6 +54,7 @@ class SNSNotification(object):
 
         return sns_regions
 
+    def _get_topic_arn(self, topic_name: str, region_name: str) -> str:
         """
         Calculate topic ARN based on partition, region, account and topic name
         :param topic_name: Name of topic
@@ -65,40 +65,41 @@ class SNSNotification(object):
         :rtype: str
         """
 
-        stsclient: STSClient = boto3.client("sts", region_name=self._region_name)
+        stsclient: STSClient = boto3.client("sts", region_name=region_name)
         resp = stsclient.get_caller_identity()
 
         account = resp["Account"]
         # resp["Arn"] has string format "arn:partition:iam::accountnumber:user/iam_role"
         partition = resp["Arn"].rsplit(":")[1]
 
-        return f"arn:{partition}:sns:{self._region_name}:{account}:{topic_name}"
+        return f"arn:{partition}:sns:{region_name}:{account}:{topic_name}"
 
     def publish(self) -> None:
         """
         send notification to subscribers
         """
 
-        snsclient: SNSClient = boto3.client("sns", region_name=self._region_name)
-
         for topic in self.conf:
             for topic_name, topic_config in topic.items():
-                try:
-                    snsclient.publish(
-                        TopicArn=self._get_topic_arn(topic_name),
-                        Subject=topic_config["subject"],
-                        Message=json.dumps(topic_config["message"]),
-                        MessageStructure="json",
-                    )
-                except ClientError as e:
-                    exception_code: str = e.response["Error"]["Code"]
-                    if exception_code == "AuthorizationError":
-                        raise AWSAuthorizationException(
-                            "Profile does not have a permission to send the SNS notification. Please review the policy."
+                for region_name in self._sns_regions(topic_config):
+                    snsclient: SNSClient = boto3.client("sns", region_name=region_name)
+                    try:
+                        snsclient.publish(
+                            TopicArn=self._get_topic_arn(topic_name, region_name),
+                            Subject=topic_config["subject"],
+                            Message=json.dumps(topic_config["message"]),
+                            MessageStructure="json",
                         )
-                    else:
-                        raise AWSNotificationException(str(e))
-                logger.info(
-                    f"The SNS notification {topic_config['subject']}"
-                    f" for the topic {topic_name} in {self._region_name} has been sent."
-                )
+                    except ClientError as e:
+                        exception_code: str = e.response["Error"]["Code"]
+                        if exception_code == "AuthorizationError":
+                            raise AWSAuthorizationException(
+                                "Profile does not have a permission to send the SNS notification."
+                                " Please review the policy."
+                            )
+                        else:
+                            raise AWSNotificationException(str(e))
+                    logger.info(
+                        f"The SNS notification {topic_config['subject']}"
+                        f" for the topic {topic_name} in {region_name} has been sent."
+                    )

--- a/awspub/tests/fixtures/config1.yaml
+++ b/awspub/tests/fixtures/config1.yaml
@@ -130,6 +130,8 @@ awspub:
             message:
               default: "default-message"
               email: "email-message"
+            regions:
+              - "us-east-1"
     "test-image-11":
       boot_mode: "uefi"
       description: |
@@ -143,10 +145,27 @@ awspub:
             message:
               default: "default-message"
               email: "email-message"
+            regions:
+              - "us-east-1"
         - "topic2":
             subject: "topic2-subject"
             message:
               default: "default-message"
+            regions:
+              - "us-gov-1"
+              - "eu-central-1"
+    "test-image-12":
+      boot_mode: "uefi"
+      description: |
+        A test image without a separate snapshot but single sns configs
+      regions:
+        - "us-east-1"
+      sns:
+        - "topic1":
+            subject: "topic1-subject"
+            message:
+              default: "default-message"
+              email: "email-message"
 
   tags:
     name: "foobar"

--- a/awspub/tests/test_api.py
+++ b/awspub/tests/test_api.py
@@ -25,6 +25,7 @@ curdir = pathlib.Path(__file__).parent.resolve()
                 "test-image-9",
                 "test-image-10",
                 "test-image-11",
+                "test-image-12",
             ],
         ),
         # with a group that no image as, no image should be processed

--- a/awspub/tests/test_common.py
+++ b/awspub/tests/test_common.py
@@ -1,6 +1,8 @@
+from unittest.mock import patch
+
 import pytest
 
-from awspub.common import _split_partition
+from awspub.common import _get_regions, _split_partition
 
 
 @pytest.mark.parametrize(
@@ -14,3 +16,19 @@ from awspub.common import _split_partition
 )
 def test_common__split_partition(input, expected_output):
     assert _split_partition(input) == expected_output
+
+
+@pytest.mark.parametrize(
+    "regions_in_partition,configured_regions,expected_output",
+    [
+        (["region-1", "region-2"], ["region-1", "region-3"], ["region-1"]),
+        (["region-1", "region-2", "region-3"], ["region-4", "region-5"], []),
+        (["region-1", "region-2"], [], ["region-1", "region-2"]),
+    ],
+)
+def test_common__get_regions(regions_in_partition, configured_regions, expected_output):
+    with patch("boto3.client") as bclient_mock:
+        instance = bclient_mock.return_value
+        instance.describe_regions.return_value = {"Regions": [{"RegionName": r} for r in regions_in_partition]}
+
+        assert _get_regions("", configured_regions) == expected_output

--- a/awspub/tests/test_image.py
+++ b/awspub/tests/test_image.py
@@ -143,6 +143,7 @@ def test_image___get_root_device_snapshot_id(root_device_name, block_device_mapp
         ("test-image-8", "aws-cn", True, True, False, True, False),
         ("test-image-10", "aws", False, False, False, False, True),
         ("test-image-11", "aws", False, False, False, False, True),
+        ("test-image-12", "aws", False, False, False, False, True),
     ],
 )
 def test_image_publish(
@@ -183,7 +184,6 @@ def test_image_publish(
             "Regions": [{"RegionName": "eu-central-1"}, {"RegionName": "us-east-1"}]
         }
         instance.list_buckets.return_value = {"Buckets": [{"Name": "bucket1"}]}
-        instance.list_topics.return_value = {"Topics": [{"TopicArn": "arn:aws:sns:topic1"}]}
         ctx = context.Context(curdir / "fixtures/config1.yaml", None)
         img = image.Image(ctx, imagename)
         img.publish()

--- a/awspub/tests/test_sns.py
+++ b/awspub/tests/test_sns.py
@@ -13,7 +13,8 @@ curdir = pathlib.Path(__file__).parent.resolve()
     "imagename,called_sns_publish, publish_call_count",
     [
         ("test-image-10", True, 1),
-        ("test-image-11", True, 4),
+        ("test-image-11", True, 2),
+        ("test-image-12", True, 2),
     ],
 )
 def test_sns_publish(imagename, called_sns_publish, publish_call_count):
@@ -23,11 +24,12 @@ def test_sns_publish(imagename, called_sns_publish, publish_call_count):
     with patch("boto3.client") as bclient_mock:
         instance = bclient_mock.return_value
         ctx = context.Context(curdir / "fixtures/config1.yaml", None)
-        image_conf = ctx.conf["images"][imagename]
+        instance.describe_regions.return_value = {
+            "Regions": [{"RegionName": "eu-central-1"}, {"RegionName": "us-east-1"}]
+        }
+        instance.list_buckets.return_value = {"Buckets": [{"Name": "bucket1"}]}
 
-        for region in image_conf["regions"]:
-            sns.SNSNotification(ctx, imagename, region).publish()
-
+        sns.SNSNotification(ctx, imagename).publish()
         assert instance.publish.called == called_sns_publish
         assert instance.publish.call_count == publish_call_count
 
@@ -37,6 +39,7 @@ def test_sns_publish(imagename, called_sns_publish, publish_call_count):
     [
         ("test-image-10"),
         ("test-image-11"),
+        ("test-image-12"),
     ],
 )
 def test_sns_publish_fail_with_invalid_topic(imagename):
@@ -46,12 +49,15 @@ def test_sns_publish_fail_with_invalid_topic(imagename):
     with patch("boto3.client") as bclient_mock:
         instance = bclient_mock.return_value
         ctx = context.Context(curdir / "fixtures/config1.yaml", None)
-        image_conf = ctx.conf["images"][imagename]
+        instance.describe_regions.return_value = {
+            "Regions": [{"RegionName": "eu-central-1"}, {"RegionName": "us-east-1"}]
+        }
+        instance.list_buckets.return_value = {"Buckets": [{"Name": "bucket1"}]}
 
         # topic1 is invalid topic
         def side_effect(*args, **kwargs):
             topic_arn = kwargs.get("TopicArn")
-            if "topic1" in topic_arn:
+            if "topic1" in topic_arn and "us-east-1" in topic_arn:
                 error_reponse = {
                     "Error": {
                         "Code": "NotFoundException",
@@ -63,9 +69,8 @@ def test_sns_publish_fail_with_invalid_topic(imagename):
 
         instance.publish.side_effect = side_effect
 
-        for region in image_conf["regions"]:
-            with pytest.raises(exceptions.AWSNotificationException):
-                sns.SNSNotification(ctx, imagename, region).publish()
+        with pytest.raises(exceptions.AWSNotificationException):
+            sns.SNSNotification(ctx, imagename).publish()
 
 
 @pytest.mark.parametrize(
@@ -73,6 +78,7 @@ def test_sns_publish_fail_with_invalid_topic(imagename):
     [
         ("test-image-10"),
         ("test-image-11"),
+        ("test-image-12"),
     ],
 )
 def test_sns_publish_fail_with_unauthorized_user(imagename):
@@ -82,7 +88,10 @@ def test_sns_publish_fail_with_unauthorized_user(imagename):
     with patch("boto3.client") as bclient_mock:
         instance = bclient_mock.return_value
         ctx = context.Context(curdir / "fixtures/config1.yaml", None)
-        image_conf = ctx.conf["images"][imagename]
+        instance.describe_regions.return_value = {
+            "Regions": [{"RegionName": "eu-central-1"}, {"RegionName": "us-east-1"}]
+        }
+        instance.list_buckets.return_value = {"Buckets": [{"Name": "bucket1"}]}
 
         error_reponse = {
             "Error": {
@@ -92,49 +101,89 @@ def test_sns_publish_fail_with_unauthorized_user(imagename):
         }
         instance.publish.side_effect = botocore.exceptions.ClientError(error_reponse, "")
 
-        for region in image_conf["regions"]:
-            with pytest.raises(exceptions.AWSAuthorizationException):
-                sns.SNSNotification(ctx, imagename, region).publish()
+        with pytest.raises(exceptions.AWSAuthorizationException):
+            sns.SNSNotification(ctx, imagename).publish()
 
 
 @pytest.mark.parametrize(
-    "imagename, partition, expected",
+    "imagename, partition, regions_in_partition, expected",
     [
         (
             "test-image-10",
             "aws-cn",
-            [
-                "arn:aws-cn:sns:us-east-1:1234:topic1",
-            ],
+            ["cn-north1", "cn-northwest-1"],
+            [],
         ),
         (
             "test-image-11",
             "aws",
+            ["us-east-1", "eu-central-1"],
             [
                 "arn:aws:sns:us-east-1:1234:topic1",
-                "arn:aws:sns:us-east-1:1234:topic2",
-                "arn:aws:sns:eu-central-1:1234:topic1",
                 "arn:aws:sns:eu-central-1:1234:topic2",
+            ],
+        ),
+        (
+            "test-image-12",
+            "aws",
+            ["us-east-1", "eu-central-1"],
+            [
+                "arn:aws:sns:us-east-1:1234:topic1",
+                "arn:aws:sns:eu-central-1:1234:topic1",
             ],
         ),
     ],
 )
-def test_sns__get_topic_arn(imagename, partition, expected):
+def test_sns__get_topic_arn(imagename, partition, regions_in_partition, expected):
     """
     Test the send_notification logic
     """
     with patch("boto3.client") as bclient_mock:
         instance = bclient_mock.return_value
         ctx = context.Context(curdir / "fixtures/config1.yaml", None)
-        image_conf = ctx.conf["images"][imagename]
+        sns_conf = ctx.conf["images"][imagename]["sns"]
+        instance.describe_regions.return_value = {"Regions": [{"RegionName": r} for r in regions_in_partition]}
+        instance.list_buckets.return_value = {"Buckets": [{"Name": "bucket1"}]}
 
         instance.get_caller_identity.return_value = {"Account": "1234", "Arn": f"arn:{partition}:iam::1234:user/test"}
 
         topic_arns = []
-        for region in image_conf["regions"]:
-            for topic in image_conf["sns"]:
-                topic_name = next(iter(topic))
-                res_arn = sns.SNSNotification(ctx, imagename, region)._get_topic_arn(topic_name)
-                topic_arns.append(res_arn)
+        for topic in sns_conf:
+            for topic_name, topic_conf in topic.items():
+                sns_regions = sns.SNSNotification(ctx, imagename)._sns_regions(topic_conf)
+                for region in sns_regions:
+                    res_arn = sns.SNSNotification(ctx, imagename)._get_topic_arn(topic_name, region)
+                    topic_arns.append(res_arn)
 
         assert topic_arns == expected
+
+
+@pytest.mark.parametrize(
+    "imagename,regions_in_partition,regions_expected",
+    [
+        ("test-image-10", ["us-east-1", "eu-west-1"], {"topic1": ["us-east-1"]}),
+        (
+            "test-image-11",
+            ["us-east-1", "eu-west-1"],
+            {"topic1": ["us-east-1"], "topic2": []},
+        ),
+        ("test-image-12", ["eu-northwest-1", "ap-southeast-1"], {"topic1": ["eu-northwest-1", "ap-southeast-1"]}),
+    ],
+)
+def test_sns_regions(imagename, regions_in_partition, regions_expected):
+    """
+    Test the regions for a given image
+    """
+    with patch("boto3.client") as bclient_mock:
+        instance = bclient_mock.return_value
+        instance.describe_regions.return_value = {"Regions": [{"RegionName": r} for r in regions_in_partition]}
+        ctx = context.Context(curdir / "fixtures/config1.yaml", None)
+        sns_conf = ctx.conf["images"][imagename]["sns"]
+        instance.list_buckets.return_value = {"Buckets": [{"Name": "bucket1"}]}
+
+        sns_regions = {}
+        for topic in sns_conf:
+            for topic_name, topic_conf in topic.items():
+                sns_regions[topic_name] = sns.SNSNotification(ctx, imagename)._sns_regions(topic_conf)
+
+        assert sns_regions == regions_expected

--- a/docs/config-samples/config-minimal-sns.yaml
+++ b/docs/config-samples/config-minimal-sns.yaml
@@ -17,3 +17,5 @@ awspub:
             subject: "my-topic2-subject"
             message:
               default: "This is message for email protocols. New image $serial is available"
+            regions:
+              - us-east-1

--- a/docs/how_to/publish.rst
+++ b/docs/how_to/publish.rst
@@ -242,7 +242,8 @@ SNS Notification
 ~~~~~~~~~~~~~~~~
 
 It's possible to publish messages through the `Simple Notification Service (SNS) <https://docs.aws.amazon.com/sns/latest/dg/welcome.html>`_.
-Delivery to multiple topics is possible, but the topics need to exist in each of the regions an image gets published.
+Delivery to multiple topics is possible, but the topics need to exist in each of the regions where the notification will be sent.
+
 To notify image information to users, the ``sns`` configuration for each image must be filled:
 
 .. literalinclude:: ../config-samples/config-minimal-sns.yaml
@@ -256,6 +257,8 @@ along with a corresponding mapping file:
 Currently, the supported protocols are ``default`` and ``email`` only, and the ``default`` key is required to 
 send notifications.
 The ``default`` message will be used as a fallback message for any protocols.
+
+Also, Regions can also be specified in ``sns`` configuration to indicate where the notification should be sent. If no regions are specified, SNS will default to using all regions in the partition.
 
 Create the image and use the `publish` command to publish the image and also notify the published images to users:
 


### PR DESCRIPTION
This fix enables the SNS config to specify a
list of regions for sending notifications.

Users can send notifications to specific regions,
but the notification will be sent in every regions if not specified.