### PR TITLE
feat: allow partial image registration

### DIFF
--- a/awspub/exceptions.py
+++ b/awspub/exceptions.py
@@ -10,6 +10,10 @@ class MultipleImagesException(Exception):
     pass
 
 
+class IncompleteImageSetException(Exception):
+    pass
+
+
 class BucketDoesNotExistException(Exception):
     def __init__(self, bucket_name: str, *args, **kwargs):
         msg = f"The bucket named '{bucket_name}' does not exist. You will need to create the bucket before proceeding."


### PR DESCRIPTION
this changes the `awspub create` route to allow images to be distributed to all regions where permission errors do not occur. 

i would like input on if we still want the operation to fail (i.e. ensure a non-zero exit code) or if we want to 'pass with warnings'. if we maintain this implementation then consuming pipelines can pass downstream and perhaps 'release successfully' for all stable regions. this does introduce incomplete sets, but errors could be corrected out of band. current infrastructure won't catch such errors though.