### PR TITLE
feat: let renovate automerge minor version bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,20 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "config:recommended"
+    ],
+    "packageRules": [
+        {
+            "groupName": "all non-major dependencies",
+            "groupSlug": "all-minor-patch",
+            "matchPackageNames": [
+                "*"
+            ],
+            "matchUpdateTypes": [
+                "minor",
+                "patch"
+            ],
+            "matchCurrentVersion": "!/^0/",
+            "automerge": true
+        }
     ]
 }


### PR DESCRIPTION
There's no need to merge those manually if testing passes. So let renovate automerge those.

Refs:
https://docs.renovatebot.com/key-concepts/automerge/#automerge-non-major-updates