### PR TITLE
Add support for sharing with Organizations and Organizational Units

### DIFF
--- a/awspub/common.py
+++ b/awspub/common.py
@@ -15,13 +15,20 @@ def _split_partition(val: str) -> Tuple[str, str]:
     :return: the partition and the resource
     :rtype: Tuple[str, str]
     """
-    if ":" in val:
-        partition, resource = val.split(":")
-    else:
-        # if no partition is given, assume default commercial partition "aws"
-        partition = "aws"
-        resource = val
-    return partition, resource
+
+    # ARNs encode partition https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html
+    if val.startswith("arn:"):
+        arn, partition, resource = val.split(":", maxsplit=2)
+        # Return extracted partition, but keep full ARN intact
+        return partition, val
+
+    # Partition prefix
+    if ":" in val and val.startswith("aws"):
+        partition, resource = val.split(":", maxsplit=1)
+        return partition, resource
+
+    # if no partition is given, assume default commercial partition "aws"
+    return "aws", val
 
 
 def _get_regions(region_to_query: str, regions_allowlist: List[str]) -> List[str]:

--- a/awspub/tests/fixtures/config1.yaml
+++ b/awspub/tests/fixtures/config1.yaml
@@ -83,6 +83,8 @@ awspub:
         - "221020170000"
         - "aws:290620200000"
         - "aws-cn:334455667788"
+        - "arn:aws:organizations::123456789012:organization/o-123example"
+        - "arn:aws-cn:organizations::334455667788:ou/o-123example/ou-1234-5example"
       marketplace:
         entity_id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
         access_role_arn: "arn:aws:iam::xxxxxxxxxxxx:role/AWSMarketplaceAccess"

--- a/awspub/tests/test_common.py
+++ b/awspub/tests/test_common.py
@@ -12,6 +12,30 @@ from awspub.common import _get_regions, _split_partition
         ("aws:123456789123", ("aws", "123456789123")),
         ("aws-cn:123456789123", ("aws-cn", "123456789123")),
         ("aws-us-gov:123456789123", ("aws-us-gov", "123456789123")),
+        (
+            "arn:aws:organizations::123456789012:organization/o-123example",
+            ("aws", "arn:aws:organizations::123456789012:organization/o-123example"),
+        ),
+        (
+            "arn:aws:organizations::123456789012:ou/o-123example/ou-1234-5example",
+            ("aws", "arn:aws:organizations::123456789012:ou/o-123example/ou-1234-5example"),
+        ),
+        (
+            "arn:aws-cn:organizations::123456789012:organization/o-123example",
+            ("aws-cn", "arn:aws-cn:organizations::123456789012:organization/o-123example"),
+        ),
+        (
+            "arn:aws-cn:organizations::123456789012:ou/o-123example/ou-1234-5example",
+            ("aws-cn", "arn:aws-cn:organizations::123456789012:ou/o-123example/ou-1234-5example"),
+        ),
+        (
+            "arn:aws-us-gov:organizations::123456789012:organization/o-123example",
+            ("aws-us-gov", "arn:aws-us-gov:organizations::123456789012:organization/o-123example"),
+        ),
+        (
+            "arn:aws-us-gov:organizations::123456789012:ou/o-123example/ou-1234-5example",
+            ("aws-us-gov", "arn:aws-us-gov:organizations::123456789012:ou/o-123example/ou-1234-5example"),
+        ),
     ],
 )
 def test_common__split_partition(input, expected_output):

--- a/awspub/tests/test_image.py
+++ b/awspub/tests/test_image.py
@@ -478,14 +478,38 @@ def test_image__verify(image_found, config, config_image_name, expected_problems
 
 
 @pytest.mark.parametrize(
-    "partition,imagename,share_list_expected",
+    "partition,imagename,share_list_expected,volume_list_expected",
     [
-        ("aws", "test-image-8", [{"UserId": "123456789123"}, {"UserId": "221020170000"}, {"UserId": "290620200000"}]),
-        ("aws-cn", "test-image-8", [{"UserId": "334455667788"}]),
-        ("aws-us-gov", "test-image-8", []),
+        (
+            "aws",
+            "test-image-8",
+            [
+                {"UserId": "123456789123"},
+                {"UserId": "221020170000"},
+                {"UserId": "290620200000"},
+                {"OrganizationArn": "arn:aws:organizations::123456789012:organization/o-123example"},
+            ],
+            [
+                {"UserId": "123456789123"},
+                {"UserId": "221020170000"},
+                {"UserId": "290620200000"},
+            ],
+        ),
+        (
+            "aws-cn",
+            "test-image-8",
+            [
+                {"UserId": "334455667788"},
+                {"OrganizationalUnitArn": "arn:aws-cn:organizations::334455667788:ou/o-123example/ou-1234-5example"},
+            ],
+            [
+                {"UserId": "334455667788"},
+            ],
+        ),
+        ("aws-us-gov", "test-image-8", [], []),
     ],
 )
-def test_image__share_list_filtered(partition, imagename, share_list_expected):
+def test_image__share_list_filtered(partition, imagename, share_list_expected, volume_list_expected):
     """
     Test _share_list_filtered() for a given image
     """
@@ -494,7 +518,7 @@ def test_image__share_list_filtered(partition, imagename, share_list_expected):
         instance.meta.partition = partition
         ctx = context.Context(curdir / "fixtures/config1.yaml", None)
         img = image.Image(ctx, imagename)
-        assert img._share_list_filtered(img.conf["share"]) == share_list_expected
+        assert img._share_list_filtered(img.conf["share"]) == (share_list_expected, volume_list_expected)
 
 
 @patch("awspub.s3.S3.bucket_region", return_value="region1")

--- a/docs/config-samples/config-minimal-share.yaml
+++ b/docs/config-samples/config-minimal-share.yaml
@@ -10,3 +10,5 @@ awspub:
       share:
         - "123456789123"
         - "aws-cn:456789012345"
+        - "arn:aws:organizations::123456789012:organization/o-123example"
+        - "arn:aws-cn:organizations::334455667788:ou/o-123example/ou-1234-5example"

--- a/docs/how_to/publish.rst
+++ b/docs/how_to/publish.rst
@@ -199,6 +199,9 @@ In the above example, the image `my-custom-image` will be shared with the accoun
 when `awspub` runs in the commercial partition (``aws``, the default). It'll be shared
 with the account `456789012345` when `awspub` runs in the the china partition (``aws-cn``).
 
+Also sharing with an organization and organisation units is available by organization or organisational
+unit ARN (which already encodes partition).
+
 AWS Marketplace
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR extends "share:" schema to support sharing images with
organizations & organization units by ARN.

Fixes: #105
