### PR TITLE
chore: add log indicating intended publication of image

### DIFF
--- a/awspub/image.py
+++ b/awspub/image.py
@@ -313,6 +313,7 @@ class Image:
             ec2client_region: EC2Client = boto3.client("ec2", region_name=region)
             image_info: Optional[_ImageInfo] = self._get(ec2client_region)
             if image_info:
+                logger.info(f"publishing {self.image_name} in region {region}")
                 ec2client_region.modify_image_attribute(
                     ImageId=image_info.image_id,
                     LaunchPermission={


### PR DESCRIPTION
If an error occurs due to quota issues the user previously had no concrete way of knowing which region caused the failure. This log indicates which region is being worked.