### PR TITLE
fix: allow marketplace version update without any existing version

### DIFF
--- a/awspub/image_marketplace.py
+++ b/awspub/image_marketplace.py
@@ -37,7 +37,7 @@ class ImageMarketplace:
         """
         entity = self._mpclient.describe_entity(Catalog="AWSMarketplace", EntityId=self.conf["entity_id"])
         # check if the version already exists
-        for version in entity["DetailsDocument"]["Versions"]:
+        for version in entity["DetailsDocument"].get("Versions", []):
             if version["VersionTitle"] == self.conf["version_title"]:
                 logger.info(f"Marketplace version '{self.conf['version_title']}' already exists. Do nothing")
                 return

--- a/awspub/tests/test_image_marketplace.py
+++ b/awspub/tests/test_image_marketplace.py
@@ -30,6 +30,19 @@ def test_image_marketplace_request_new_version(imagename, new_version, called_st
         assert instance.start_change_set.called == called_start_change_set
 
 
+def test_image_marketplace_request_new_version_none_exists():
+    """
+    Test the request_new_version logic if no version exist already
+    """
+    with patch("boto3.client") as bclient_mock:
+        instance = bclient_mock.return_value
+        instance.describe_entity.return_value = {"DetailsDocument": {}}
+        ctx = context.Context(curdir / "fixtures/config1.yaml", None)
+        img = image_marketplace.ImageMarketplace(ctx, "test-image-8")
+        img.request_new_version("ami-123")
+        assert instance.start_change_set.called is True
+
+
 @pytest.mark.parametrize(
     "name,expected",
     [


### PR DESCRIPTION
If the marketplace listing doesn't have a version yet, do allow to create a new version request.
This fixes:

File "awspub/image_marketplace.py", line 40, in request_new_version
    for version in entity["DetailsDocument"]["Versions"]:
                   ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
KeyError: 'Versions'