### PR TITLE
feat: support aws credential and region overrides

### DIFF
--- a/awspub/common.py
+++ b/awspub/common.py
@@ -50,7 +50,7 @@ def _get_regions(region_to_query: str, regions_allowlist: List[str]) -> List[str
     """
 
     # get all available regions
-    ec2client: EC2Client = boto3.client("ec2", region_name=region_to_query)
+    ec2client: EC2Client = _get_client("ec2", region_name=region_to_query)
     resp = ec2client.describe_regions()
     ec2_regions_all = [r["RegionName"] for r in resp["Regions"]]
 
@@ -69,3 +69,7 @@ def _get_regions(region_to_query: str, regions_allowlist: List[str]) -> List[str
         regions = ec2_regions_all
 
     return regions
+
+
+def _get_client(service, **kwargs):
+    return boto3.client(service, **kwargs)

--- a/awspub/image.py
+++ b/awspub/image.py
@@ -4,13 +4,12 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
-import boto3
 import botocore.exceptions
 from mypy_boto3_ec2.client import EC2Client
 from mypy_boto3_ssm import SSMClient
 
 from awspub import exceptions
-from awspub.common import _get_regions, _split_partition
+from awspub.common import _get_client, _get_regions, _split_partition
 from awspub.context import Context
 from awspub.image_marketplace import ImageMarketplace
 from awspub.s3 import S3
@@ -154,7 +153,7 @@ class Image:
         :rtype: Tuple[List[Dict[str, str]], List[Dict[str, str]]]
         """
         # the current partition
-        partition_current = boto3.client("ec2").meta.partition
+        partition_current = _get_client("ec2").meta.partition
 
         share_list: List[Dict[str, str]] = []
         volume_list: List[Dict[str, str]] = []
@@ -186,7 +185,7 @@ class Image:
             return
 
         for region, image_info in images.items():
-            ec2client: EC2Client = boto3.client("ec2", region_name=region)
+            ec2client: EC2Client = _get_client("ec2", region_name=region)
             # modify image permissions
             ec2client.modify_image_attribute(
                 Attribute="LaunchPermission",
@@ -264,7 +263,7 @@ class Image:
         """
         logger.info(f"Pushing SSM parameters for image {self.image_name} in {len(self.image_regions)} regions ...")
         for region in self.image_regions:
-            ec2client_region: EC2Client = boto3.client("ec2", region_name=region)
+            ec2client_region: EC2Client = _get_client("ec2", region_name=region)
             image_info: Optional[_ImageInfo] = self._get(ec2client_region)
 
             # image in region not found
@@ -272,7 +271,7 @@ class Image:
                 logger.error(f"image {self.image_name} not available in region {region}. can not push SSM parameter")
                 continue
 
-            ssmclient_region: SSMClient = boto3.client("ssm", region_name=region)
+            ssmclient_region: SSMClient = _get_client("ssm", region_name=region)
             # iterate over all defined parameters
             for parameter in self.conf["ssm_parameter"]:
                 # if overwrite is not allowed, check if the parameter is already there and if so, do nothing
@@ -310,7 +309,7 @@ class Image:
         logger.info(f"Make image {self.image_name} in {len(self.image_regions)} regions public ...")
 
         for region in self.image_regions:
-            ec2client_region: EC2Client = boto3.client("ec2", region_name=region)
+            ec2client_region: EC2Client = _get_client("ec2", region_name=region)
             image_info: Optional[_ImageInfo] = self._get(ec2client_region)
             if image_info:
                 logger.info(f"publishing {self.image_name} in region {region}")
@@ -371,7 +370,7 @@ class Image:
         # do the cleanup - the image is marked as temporary
         logger.info(f"Cleanup image {self.image_name} ...")
         for region in self.image_regions:
-            ec2client_region: EC2Client = boto3.client("ec2", region_name=region)
+            ec2client_region: EC2Client = _get_client("ec2", region_name=region)
             image_info: Optional[_ImageInfo] = self._get(ec2client_region)
 
             if image_info:
@@ -400,7 +399,7 @@ class Image:
         """
         images: Dict[str, _ImageInfo] = dict()
         for region in self.image_regions:
-            ec2client_region: EC2Client = boto3.client("ec2", region_name=region)
+            ec2client_region: EC2Client = _get_client("ec2", region_name=region)
             image_info: Optional[_ImageInfo] = self._get(ec2client_region)
             if image_info:
                 images[region] = image_info
@@ -416,7 +415,7 @@ class Image:
         :rtype: Dict[str, _ImageInfo]
         """
         # this **must** be the region that is used for S3
-        ec2client: EC2Client = boto3.client("ec2", region_name=self._s3.bucket_region)
+        ec2client: EC2Client = _get_client("ec2", region_name=self._s3.bucket_region)
 
         # make sure the initial snapshot exists
         self._snapshot.create(ec2client, self.snapshot_name)
@@ -429,7 +428,7 @@ class Image:
         images: Dict[str, _ImageInfo] = dict()
         missing_regions: List[str] = []
         for region in self.image_regions:
-            ec2client_region: EC2Client = boto3.client("ec2", region_name=region)
+            ec2client_region: EC2Client = _get_client("ec2", region_name=region)
             image_info: Optional[_ImageInfo] = self._get(ec2client_region)
             if image_info:
                 if image_info.snapshot_id != snapshot_ids[region]:
@@ -452,7 +451,7 @@ class Image:
         # wait for the images
         logger.info(f"Waiting for {len(images)} images to be ready the regions ...")
         for region, image_info in images.items():
-            ec2client_region_wait: EC2Client = boto3.client("ec2", region_name=region)
+            ec2client_region_wait: EC2Client = _get_client("ec2", region_name=region)
             logger.info(
                 f"Waiting for {image_info.image_id} in {ec2client_region_wait.meta.region_name} "
                 "to exist/be available ..."
@@ -567,11 +566,11 @@ class Image:
         # handle marketplace publication
         if self.conf["marketplace"]:
             # the "marketplace" configuration is only valid in the "aws" partition
-            partition = boto3.client("ec2").meta.partition
+            partition = _get_client("ec2").meta.partition
             if partition == "aws":
                 logger.info(f"marketplace version request for {self.image_name}")
                 # image needs to be in us-east-1
-                ec2client: EC2Client = boto3.client("ec2", region_name="us-east-1")
+                ec2client: EC2Client = _get_client("ec2", region_name="us-east-1")
                 image_info: Optional[_ImageInfo] = self._get(ec2client)
                 if image_info:
                     im = ImageMarketplace(self._ctx, self.image_name)

--- a/awspub/image_marketplace.py
+++ b/awspub/image_marketplace.py
@@ -2,9 +2,9 @@ import logging
 import re
 from typing import Any, Dict
 
-import boto3
 from mypy_boto3_marketplace_catalog import MarketplaceCatalogClient
 
+from awspub.common import _get_client
 from awspub.context import Context
 
 logger = logging.getLogger(__name__)
@@ -19,7 +19,7 @@ class ImageMarketplace:
         self._ctx: Context = context
         self._image_name: str = image_name
         # marketplace-catalog API is only available via us-east-1
-        self._mpclient: MarketplaceCatalogClient = boto3.client("marketplace-catalog", region_name="us-east-1")
+        self._mpclient: MarketplaceCatalogClient = _get_client("marketplace-catalog", region_name="us-east-1")
 
     @property
     def conf(self) -> Dict[str, Any]:

--- a/awspub/s3.py
+++ b/awspub/s3.py
@@ -4,11 +4,12 @@ import logging
 import os
 from typing import Dict
 
-import boto3
 from mypy_boto3_s3.type_defs import CompletedPartTypeDef
 
 from awspub.context import Context
 from awspub.exceptions import BucketDoesNotExistException
+
+from .common import _get_client
 
 # chunk size is required for calculating the checksums
 MULTIPART_CHUNK_SIZE = 8 * 1024 * 1024
@@ -28,7 +29,7 @@ class S3:
         "type context: awspub.context.Context
         """
         self._ctx: Context = context
-        self._s3client = boto3.client("s3")
+        self._s3client = _get_client("s3")
         self._bucket_region = None
 
     @property

--- a/awspub/snapshot.py
+++ b/awspub/snapshot.py
@@ -1,10 +1,10 @@
 import logging
 from typing import Dict, List, Optional
 
-import boto3
 from mypy_boto3_ec2.client import EC2Client
 
 from awspub import exceptions
+from awspub.common import _get_client
 from awspub.context import Context
 
 logger = logging.getLogger(__name__)
@@ -184,7 +184,7 @@ class Snapshot:
         """
 
         # does the snapshot with that name already exist in the destination region?
-        ec2client_dest: EC2Client = boto3.client("ec2", region_name=destination_region)
+        ec2client_dest: EC2Client = _get_client("ec2", region_name=destination_region)
         snapshot_id: Optional[str] = self._get(ec2client_dest, snapshot_name)
         if snapshot_id:
             logger.info(
@@ -193,7 +193,7 @@ class Snapshot:
             )
             return snapshot_id
 
-        ec2client_source: EC2Client = boto3.client("ec2", region_name=source_region)
+        ec2client_source: EC2Client = _get_client("ec2", region_name=source_region)
         source_snapshot_id: Optional[str] = self._get(ec2client_source, snapshot_name)
         if not source_snapshot_id:
             raise ValueError(
@@ -233,7 +233,7 @@ class Snapshot:
 
         logger.info(f"Waiting for {len(snapshot_ids)} snapshots to appear in the destination regions ...")
         for destination_region, snapshot_id in snapshot_ids.items():
-            ec2client_dest = boto3.client("ec2", region_name=destination_region)
+            ec2client_dest = _get_client("ec2", region_name=destination_region)
             waiter = ec2client_dest.get_waiter("snapshot_completed")
             logger.info(f"Waiting for {snapshot_id} in {ec2client_dest.meta.region_name} to complete ...")
             waiter.wait(SnapshotIds=[snapshot_id], WaiterConfig={"Delay": 30, "MaxAttempts": 90})

--- a/awspub/sns.py
+++ b/awspub/sns.py
@@ -6,12 +6,11 @@ import json
 import logging
 from typing import Any, Dict, List
 
-import boto3
 from botocore.exceptions import ClientError
 from mypy_boto3_sns.client import SNSClient
 from mypy_boto3_sts.client import STSClient
 
-from awspub.common import _get_regions
+from awspub.common import _get_client, _get_regions
 from awspub.context import Context
 from awspub.exceptions import AWSAuthorizationException, AWSNotificationException
 from awspub.s3 import S3
@@ -65,7 +64,7 @@ class SNSNotification(object):
         :rtype: str
         """
 
-        stsclient: STSClient = boto3.client("sts", region_name=region_name)
+        stsclient: STSClient = _get_client("sts", region_name=region_name)
         resp = stsclient.get_caller_identity()
 
         account = resp["Account"]
@@ -82,7 +81,7 @@ class SNSNotification(object):
         for topic in self.conf:
             for topic_name, topic_config in topic.items():
                 for region_name in self._sns_regions(topic_config):
-                    snsclient: SNSClient = boto3.client("sns", region_name=region_name)
+                    snsclient: SNSClient = _get_client("sns", region_name=region_name)
                     try:
                         snsclient.publish(
                             TopicArn=self._get_topic_arn(topic_name, region_name),

--- a/awspub/tests/test_common.py
+++ b/awspub/tests/test_common.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from awspub.common import _get_regions, _split_partition
+from awspub.common import _get_client, _get_regions, _split_partition
 
 
 @pytest.mark.parametrize(
@@ -56,3 +56,20 @@ def test_common__get_regions(regions_in_partition, configured_regions, expected_
         instance.describe_regions.return_value = {"Regions": [{"RegionName": r} for r in regions_in_partition]}
 
         assert _get_regions("", configured_regions) == expected_output
+
+
+@pytest.mark.parametrize(
+    "service,args,expected_region",
+    [
+        ("ec2", {"region_name": "us-west-1"}, "us-west-1"),
+        ("s3", {"region_name": "eu-central-1"}, "eu-central-1"),
+    ],
+)
+def test_get_client_with_args(service, args, expected_region):
+
+    with patch("boto3.client") as client_mock:
+        _get_client(service, **args)
+
+        client_mock.assert_called_once_with(service, **args)
+        _, called_kwargs = client_mock.call_args
+        assert called_kwargs["region_name"] == expected_region

--- a/awspub/tests/test_s3.py
+++ b/awspub/tests/test_s3.py
@@ -53,11 +53,11 @@ def test_s3__get_multipart_upload_id(list_multipart_uploads_resp, create_multipa
 
 
 @patch("awspub.s3.S3._bucket_exists", return_value=True)
-@patch("awspub.s3.boto3")
-def test_s3_bucket_region_bucket_exists(boto3_mock, bucket_exists_mock):
+@patch("awspub.s3._get_client")
+def test_s3_bucket_region_bucket_exists(get_client_mock, bucket_exists_mock):
     region_name = "sample-region-1"
     head_bucket = {"BucketRegion": region_name}
-    boto3_mock.client.return_value.head_bucket.return_value = head_bucket
+    get_client_mock.return_value.head_bucket.return_value = head_bucket
     ctx = context.Context(curdir / "fixtures/config1.yaml", None)
     sthree = s3.S3(ctx)
 
@@ -65,7 +65,7 @@ def test_s3_bucket_region_bucket_exists(boto3_mock, bucket_exists_mock):
 
 
 @patch("awspub.s3.S3._bucket_exists", return_value=False)
-@patch("boto3.client")
+@patch("awspub.s3._get_client")
 def test_s3_bucket_region_bucket_not_exists(bclient_mock, bucket_exists_mock):
     ctx = context.Context(curdir / "fixtures/config1.yaml", None)
     sthree = s3.S3(ctx)


### PR DESCRIPTION
the current implementation of awspub assumes a default profile is used. this adds support to override both the credentials and target region. overriding target region is to enable publication outside of the commercial partition. 