### PR TITLE
Support `allow-partial-regions` argument

### DIFF
--- a/.github/workflows/sphinx-python-dependency-build-checks.yml
+++ b/.github/workflows/sphinx-python-dependency-build-checks.yml
@@ -51,5 +51,4 @@ jobs:
           set -ex
           make -f Makefile.sp \
             sp-install \
-            PIPOPTS="--no-binary :all:" \
             || ( cat .sphinx/venv/pip_install.log && exit 1 )

--- a/awspub/api.py
+++ b/awspub/api.py
@@ -58,7 +58,7 @@ def _images_filtered(context: Context, group: Optional[str]) -> Iterator[Tuple[s
 
 
 def create(
-    config: pathlib.Path, config_mapping: pathlib.Path, group: Optional[str]
+    config: pathlib.Path, config_mapping: pathlib.Path, allow_partial_regions: bool, group: Optional[str]
 ) -> Tuple[Dict[str, Dict[str, str]], Dict[str, Dict[str, Dict[str, str]]]]:
     """
     Create images in the partition of the used account based on
@@ -75,18 +75,21 @@ def create(
     """
 
     ctx = Context(config, config_mapping)
+    ctx.allow_partial_region = allow_partial_regions
     s3 = S3(ctx)
     s3.upload_file(ctx.conf["source"]["path"])
     images: List[Tuple[str, Image, Dict[str, _ImageInfo]]] = []
     for image_name, image in _images_filtered(ctx, group):
+        print("jess", image_name, image)
         image_result: Dict[str, _ImageInfo] = image.create()
         images.append((image_name, image, image_result))
+        print(images)
     images_by_name, images_by_group = _images_grouped(images, group)
     return images_by_name, images_by_group
 
 
 def list(
-    config: pathlib.Path, config_mapping: pathlib.Path, group: Optional[str]
+    config: pathlib.Path, config_mapping: pathlib.Path, allow_partial_regions: bool, group: Optional[str]
 ) -> Tuple[Dict[str, Dict[str, str]], Dict[str, Dict[str, Dict[str, str]]]]:
     """
     List images in the partition of the used account based on
@@ -102,6 +105,7 @@ def list(
     :rtype: Tuple[Dict[str, Dict[str, str]], Dict[str, Dict[str, Dict[str, str]]]
     """
     ctx = Context(config, config_mapping)
+    ctx.allow_partial_region = allow_partial_regions
     images: List[Tuple[str, Image, Dict[str, _ImageInfo]]] = []
     for image_name, image in _images_filtered(ctx, group):
         image_result: Dict[str, _ImageInfo] = image.list()
@@ -111,7 +115,7 @@ def list(
     return images_by_name, images_by_group
 
 
-def publish(config: pathlib.Path, config_mapping: pathlib.Path, group: Optional[str]):
+def publish(config: pathlib.Path, config_mapping: pathlib.Path, allow_partial_regions: bool, group: Optional[str]):
     """
     Make available images in the partition of the used account based on
     the given configuration file public
@@ -124,11 +128,12 @@ def publish(config: pathlib.Path, config_mapping: pathlib.Path, group: Optional[
     :type group: Optional[str]
     """
     ctx = Context(config, config_mapping)
+    ctx.allow_partial_region = allow_partial_regions
     for image_name, image in _images_filtered(ctx, group):
         image.publish()
 
 
-def cleanup(config: pathlib.Path, config_mapping: pathlib.Path, group: Optional[str]):
+def cleanup(config: pathlib.Path, config_mapping: pathlib.Path, allow_partial_regions: bool, group: Optional[str]):
     """
     Cleanup available images in the partition of the used account based on
     the given configuration file
@@ -141,5 +146,6 @@ def cleanup(config: pathlib.Path, config_mapping: pathlib.Path, group: Optional[
     :type group: Optional[str]
     """
     ctx = Context(config, config_mapping)
+    ctx.allow_partial_region = allow_partial_regions
     for image_name, image in _images_filtered(ctx, group):
         image.cleanup()

--- a/awspub/cli/__init__.py
+++ b/awspub/cli/__init__.py
@@ -16,7 +16,9 @@ def _create(args) -> None:
     Create images based on the given configuration and write json
     data to the given output
     """
-    images_by_name, images_by_group = awspub.create(args.config, args.config_mapping, args.group)
+    images_by_name, images_by_group = awspub.create(
+        args.config, args.config_mapping, args.allow_partial_regions, args.group
+    )
     images_json = json.dumps({"images": images_by_name, "images-by-group": images_by_group}, indent=4)
     args.output.write(images_json)
 
@@ -26,7 +28,9 @@ def _list(args) -> None:
     List images based on the given configuration and write json
     data to the given output
     """
-    images_by_name, images_by_group = awspub.list(args.config, args.config_mapping, args.group)
+    images_by_name, images_by_group = awspub.list(
+        args.config, args.config_mapping, args.allow_partial_regions, args.group
+    )
     images_json = json.dumps({"images": images_by_name, "images-by-group": images_by_group}, indent=4)
     args.output.write(images_json)
 
@@ -35,14 +39,14 @@ def _cleanup(args) -> None:
     """
     Cleanup available images
     """
-    awspub.cleanup(args.config, args.config_mapping, args.group)
+    awspub.cleanup(args.config, args.config_mapping, args.allow_partial_regions, args.group)
 
 
 def _publish(args) -> None:
     """
     Make available images public
     """
-    awspub.publish(args.config, args.config_mapping, args.group)
+    awspub.publish(args.config, args.config_mapping, args.allow_partial_regions, args.group)
 
 
 def _parser():
@@ -59,6 +63,12 @@ def _parser():
     )
     p_create.add_argument("--config-mapping", type=pathlib.Path, help="the image config template mapping file path")
     p_create.add_argument("--group", type=str, help="only handles images from given group")
+    p_create.add_argument(
+        "--allow-partial-regions",
+        action="store_true",
+        help="continue processing remaining regions if "
+        "a region's API request fails (e.g. due to service unavailability)",
+    )
     p_create.add_argument("config", type=pathlib.Path, help="the image configuration file path")
     p_create.set_defaults(func=_create)
 
@@ -69,6 +79,12 @@ def _parser():
     )
     p_list.add_argument("--config-mapping", type=pathlib.Path, help="the image config template mapping file path")
     p_list.add_argument("--group", type=str, help="only handles images from given group")
+    p_list.add_argument(
+        "--allow-partial-regions",
+        action="store_true",
+        help="continue processing remaining regions if "
+        "a region's API request fails (e.g. due to service unavailability)",
+    )
     p_list.add_argument("config", type=pathlib.Path, help="the image configuration file path")
     p_list.set_defaults(func=_list)
 
@@ -79,6 +95,12 @@ def _parser():
     )
     p_cleanup.add_argument("--config-mapping", type=pathlib.Path, help="the image config template mapping file path")
     p_cleanup.add_argument("--group", type=str, help="only handles images from given group")
+    p_cleanup.add_argument(
+        "--allow-partial-regions",
+        action="store_true",
+        help="continue processing remaining regions if "
+        "a region's API request fails (e.g. due to service unavailability)",
+    )
     p_cleanup.add_argument("config", type=pathlib.Path, help="the image configuration file path")
 
     p_cleanup.set_defaults(func=_cleanup)
@@ -90,6 +112,12 @@ def _parser():
     )
     p_publish.add_argument("--config-mapping", type=pathlib.Path, help="the image config template mapping file path")
     p_publish.add_argument("--group", type=str, help="only handles images from given group")
+    p_publish.add_argument(
+        "--allow-partial-regions",
+        action="store_true",
+        help="continue processing remaining regions if "
+        "a region's API request fails (e.g. due to service unavailability)",
+    )
     p_publish.add_argument("config", type=pathlib.Path, help="the image configuration file path")
 
     p_publish.set_defaults(func=_publish)

--- a/awspub/common.py
+++ b/awspub/common.py
@@ -69,3 +69,14 @@ def _get_regions(region_to_query: str, regions_allowlist: List[str]) -> List[str
         regions = ec2_regions_all
 
     return regions
+
+
+def _maybe_continue_on_region_error(allow_partial_region: bool, region: str, exc: Exception) -> None:
+    """
+    If allow_partial_region is set, log a warning; otherwise re-raise the exception.
+    """
+    if not allow_partial_region:
+        raise exc
+    logger.warning(
+        f"API request failed in region {region}: {exc} — continuing because allow-partial-regions set",
+    )

--- a/awspub/context.py
+++ b/awspub/context.py
@@ -20,6 +20,7 @@ class Context:
     def __init__(self, conf_path: pathlib.Path, conf_template_mapping_path: pathlib.Path):
         self._conf_path = conf_path
         self._conf = None
+        self.allow_partial_region: bool = False
         self._conf_template_mapping_path = conf_template_mapping_path
         self._conf_template_mapping = {}
         yaml = YAML(typ="safe")

--- a/awspub/image.py
+++ b/awspub/image.py
@@ -279,7 +279,9 @@ class Image:
 
                 # image in region not found
                 if not image_info:
-                    logger.error(f"image {self.image_name} not available in region {region}. can not push SSM parameter")
+                    logger.error(
+                        f"image {self.image_name} not available in region {region}. can not push SSM parameter"
+                    )
                     continue
 
                 ssmclient_region: SSMClient = boto3.client("ssm", region_name=region)
@@ -400,7 +402,8 @@ class Image:
                         # this shouldn't happen because the image is marked as temporary in the config
                         # so how can it be public?
                         logger.error(
-                            f"no cleanup for {self.image_name} in {region} because ({image_info.image_id}) image is public"
+                            f"no cleanup for {self.image_name} in {region} because ({image_info.image_id}) "
+                            f"image is public"
                         )
                     else:
                         ec2client_region.deregister_image(ImageId=image_info.image_id)
@@ -461,7 +464,8 @@ class Image:
                         logger.warning(
                             f"image with name '{self.image_name}' already exists ({image_info.image_id}) "
                             f"in region {ec2client_region.meta.region_name} but the root device "
-                            f"snapshot id is unexpected (got {image_info.snapshot_id} but expected {snapshot_ids[region]})"
+                            f"snapshot id is unexpected (got {image_info.snapshot_id} but expected "
+                            f"{snapshot_ids[region]})"
                         )
                     else:
                         logger.info(

--- a/awspub/image.py
+++ b/awspub/image.py
@@ -10,7 +10,11 @@ from mypy_boto3_ec2.client import EC2Client
 from mypy_boto3_ssm import SSMClient
 
 from awspub import exceptions
-from awspub.common import _get_regions, _split_partition
+from awspub.common import (
+    _get_regions,
+    _maybe_continue_on_region_error,
+    _split_partition,
+)
 from awspub.context import Context
 from awspub.image_marketplace import ImageMarketplace
 from awspub.s3 import S3
@@ -64,6 +68,7 @@ class Image:
 
         self._snapshot: Snapshot = Snapshot(context)
         self._s3: S3 = S3(context)
+        self._allow_partial_region = getattr(self._ctx, "allow_partial_region", False)
 
     def __repr__(self):
         return f"<{self.__class__} :'{self.image_name}' (snapshot name: {self.snapshot_name})"
@@ -185,22 +190,26 @@ class Image:
             logger.info("no valid accounts found for sharing in this partition, skipping")
             return
 
-        for region, image_info in images.items():
-            ec2client: EC2Client = boto3.client("ec2", region_name=region)
-            # modify image permissions
-            ec2client.modify_image_attribute(
-                Attribute="LaunchPermission",
-                ImageId=image_info.image_id,
-                LaunchPermission={"Add": share_list},  # type: ignore
-            )
-
-            # modify snapshot permissions
-            if image_info.snapshot_id and volume_list:
-                ec2client.modify_snapshot_attribute(
-                    Attribute="createVolumePermission",
-                    SnapshotId=image_info.snapshot_id,
-                    CreateVolumePermission={"Add": volume_list},  # type: ignore
+        for region, image_info in list(images.items()):
+            try:
+                ec2client: EC2Client = boto3.client("ec2", region_name=region)
+                # modify image permissions
+                ec2client.modify_image_attribute(
+                    Attribute="LaunchPermission",
+                    ImageId=image_info.image_id,
+                    LaunchPermission={"Add": share_list},  # type: ignore
                 )
+
+                # modify snapshot permissions
+                if image_info.snapshot_id and volume_list:
+                    ec2client.modify_snapshot_attribute(
+                        Attribute="createVolumePermission",
+                        SnapshotId=image_info.snapshot_id,
+                        CreateVolumePermission={"Add": volume_list},  # type: ignore
+                    )
+            except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as exc:
+                _maybe_continue_on_region_error(self._allow_partial_region, region, exc)
+                images.pop(region, None)
 
         logger.info(f"shared images & snapshots with '{share_conf}'")
 
@@ -264,44 +273,47 @@ class Image:
         """
         logger.info(f"Pushing SSM parameters for image {self.image_name} in {len(self.image_regions)} regions ...")
         for region in self.image_regions:
-            ec2client_region: EC2Client = boto3.client("ec2", region_name=region)
-            image_info: Optional[_ImageInfo] = self._get(ec2client_region)
+            try:
+                ec2client_region: EC2Client = boto3.client("ec2", region_name=region)
+                image_info: Optional[_ImageInfo] = self._get(ec2client_region)
 
-            # image in region not found
-            if not image_info:
-                logger.error(f"image {self.image_name} not available in region {region}. can not push SSM parameter")
-                continue
+                # image in region not found
+                if not image_info:
+                    logger.error(f"image {self.image_name} not available in region {region}. can not push SSM parameter")
+                    continue
 
-            ssmclient_region: SSMClient = boto3.client("ssm", region_name=region)
-            # iterate over all defined parameters
-            for parameter in self.conf["ssm_parameter"]:
-                # if overwrite is not allowed, check if the parameter is already there and if so, do nothing
-                if not parameter["allow_overwrite"]:
-                    resp = ssmclient_region.get_parameters(Names=[parameter["name"]])
-                    if len(resp["Parameters"]) >= 1:
-                        # sanity check if the available parameter matches the value we would (but don't) push
-                        if resp["Parameters"][0]["Value"] != image_info.image_id:
-                            logger.warning(
-                                f"SSM parameter {parameter['name']} exists but value does not match "
-                                f"(found {resp['Parameters'][0]['Value']}; expected: {image_info.image_id}"
-                            )
-                        # parameter exists already and overwrite is not allowed so continue
-                        continue
-                # push parameter to store
-                ssmclient_region.put_parameter(
-                    Name=parameter["name"],
-                    Description=parameter.get("description", ""),
-                    Value=image_info.image_id,
-                    Type="String",
-                    Overwrite=parameter["allow_overwrite"],
-                    DataType="aws:ec2:image",
-                    # TODO: tags can't be used together with overwrite
-                    # Tags=self._ctx.tags,
-                )
+                ssmclient_region: SSMClient = boto3.client("ssm", region_name=region)
+                # iterate over all defined parameters
+                for parameter in self.conf["ssm_parameter"]:
+                    # if overwrite is not allowed, check if the parameter is already there and if so, do nothing
+                    if not parameter["allow_overwrite"]:
+                        resp = ssmclient_region.get_parameters(Names=[parameter["name"]])
+                        if len(resp["Parameters"]) >= 1:
+                            # sanity check if the available parameter matches the value we would (but don't) push
+                            if resp["Parameters"][0]["Value"] != image_info.image_id:
+                                logger.warning(
+                                    f"SSM parameter {parameter['name']} exists but value does not match "
+                                    f"(found {resp['Parameters'][0]['Value']}; expected: {image_info.image_id}"
+                                )
+                            # parameter exists already and overwrite is not allowed so continue
+                            continue
+                    # push parameter to store
+                    ssmclient_region.put_parameter(
+                        Name=parameter["name"],
+                        Description=parameter.get("description", ""),
+                        Value=image_info.image_id,
+                        Type="String",
+                        Overwrite=parameter["allow_overwrite"],
+                        DataType="aws:ec2:image",
+                        # TODO: tags can't be used together with overwrite
+                        # Tags=self._ctx.tags,
+                    )
 
-                logger.info(
-                    f"pushed SSM parameter {parameter['name']} with value {image_info.image_id} in region {region}"
-                )
+                    logger.info(
+                        f"pushed SSM parameter {parameter['name']} with value {image_info.image_id} in region {region}"
+                    )
+            except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as exc:
+                _maybe_continue_on_region_error(self._allow_partial_region, region, exc)
 
     def _public(self) -> None:
         """
@@ -310,41 +322,44 @@ class Image:
         logger.info(f"Make image {self.image_name} in {len(self.image_regions)} regions public ...")
 
         for region in self.image_regions:
-            ec2client_region: EC2Client = boto3.client("ec2", region_name=region)
-            image_info: Optional[_ImageInfo] = self._get(ec2client_region)
-            if image_info:
-                logger.info(f"publishing {self.image_name} in region {region}")
-                ec2client_region.modify_image_attribute(
-                    ImageId=image_info.image_id,
-                    LaunchPermission={
-                        "Add": [
-                            {
-                                "Group": "all",
-                            },
-                        ],
-                    },
-                )
-                logger.info(f"image {image_info.image_id} in region {region} public now")
+            try:
+                ec2client_region: EC2Client = boto3.client("ec2", region_name=region)
+                image_info: Optional[_ImageInfo] = self._get(ec2client_region)
+                if image_info:
+                    logger.info(f"publishing {self.image_name} in region {region}")
+                    ec2client_region.modify_image_attribute(
+                        ImageId=image_info.image_id,
+                        LaunchPermission={
+                            "Add": [
+                                {
+                                    "Group": "all",
+                                },
+                            ],
+                        },
+                    )
+                    logger.info(f"image {image_info.image_id} in region {region} public now")
 
-                if image_info.snapshot_id:
-                    ec2client_region.modify_snapshot_attribute(
-                        SnapshotId=image_info.snapshot_id,
-                        Attribute="createVolumePermission",
-                        GroupNames=[
-                            "all",
-                        ],
-                        OperationType="add",
-                    )
-                    logger.info(
-                        f"snapshot {image_info.snapshot_id} ({image_info.image_id}) in region {region} public now"
-                    )
+                    if image_info.snapshot_id:
+                        ec2client_region.modify_snapshot_attribute(
+                            SnapshotId=image_info.snapshot_id,
+                            Attribute="createVolumePermission",
+                            GroupNames=[
+                                "all",
+                            ],
+                            OperationType="add",
+                        )
+                        logger.info(
+                            f"snapshot {image_info.snapshot_id} ({image_info.image_id}) in region {region} public now"
+                        )
+                    else:
+                        logger.error(
+                            f"snapshot for image {self.image_name} ({image_info.image_id}) not available "
+                            f"in region {region}. can not make public"
+                        )
                 else:
-                    logger.error(
-                        f"snapshot for image {self.image_name} ({image_info.image_id}) not available "
-                        f"in region {region}. can not make public"
-                    )
-            else:
-                logger.error(f"image {self.image_name} not available in region {region}. can not make public")
+                    logger.error(f"image {self.image_name} not available in region {region}. can not make public")
+            except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as exc:
+                _maybe_continue_on_region_error(self._allow_partial_region, region, exc)
 
     def _sns_publish(self) -> None:
         """
@@ -371,24 +386,27 @@ class Image:
         # do the cleanup - the image is marked as temporary
         logger.info(f"Cleanup image {self.image_name} ...")
         for region in self.image_regions:
-            ec2client_region: EC2Client = boto3.client("ec2", region_name=region)
-            image_info: Optional[_ImageInfo] = self._get(ec2client_region)
+            try:
+                ec2client_region: EC2Client = boto3.client("ec2", region_name=region)
+                image_info: Optional[_ImageInfo] = self._get(ec2client_region)
 
-            if image_info:
-                resp = ec2client_region.describe_images(
-                    Filters=[
-                        {"Name": "image-id", "Values": [image_info.image_id]},
-                    ]
-                )
-                if resp["Images"][0]["Public"] is True:
-                    # this shouldn't happen because the image is marked as temporary in the config
-                    # so how can it be public?
-                    logger.error(
-                        f"no cleanup for {self.image_name} in {region} because ({image_info.image_id}) image is public"
+                if image_info:
+                    resp = ec2client_region.describe_images(
+                        Filters=[
+                            {"Name": "image-id", "Values": [image_info.image_id]},
+                        ]
                     )
-                else:
-                    ec2client_region.deregister_image(ImageId=image_info.image_id)
-                    logger.info(f"{self.image_name} in {region} ({image_info.image_id}) deleted")
+                    if resp["Images"][0]["Public"] is True:
+                        # this shouldn't happen because the image is marked as temporary in the config
+                        # so how can it be public?
+                        logger.error(
+                            f"no cleanup for {self.image_name} in {region} because ({image_info.image_id}) image is public"
+                        )
+                    else:
+                        ec2client_region.deregister_image(ImageId=image_info.image_id)
+                        logger.info(f"{self.image_name} in {region} ({image_info.image_id}) deleted")
+            except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as exc:
+                _maybe_continue_on_region_error(self._allow_partial_region, region, exc)
 
     def list(self) -> Dict[str, _ImageInfo]:
         """
@@ -400,12 +418,15 @@ class Image:
         """
         images: Dict[str, _ImageInfo] = dict()
         for region in self.image_regions:
-            ec2client_region: EC2Client = boto3.client("ec2", region_name=region)
-            image_info: Optional[_ImageInfo] = self._get(ec2client_region)
-            if image_info:
-                images[region] = image_info
-            else:
-                logger.warning(f"image {self.image_name} not available in region {region}")
+            try:
+                ec2client_region: EC2Client = boto3.client("ec2", region_name=region)
+                image_info: Optional[_ImageInfo] = self._get(ec2client_region)
+                if image_info:
+                    images[region] = image_info
+                else:
+                    logger.warning(f"image {self.image_name} not available in region {region}")
+            except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as exc:
+                _maybe_continue_on_region_error(self._allow_partial_region, region, exc)
         return images
 
     def create(self) -> Dict[str, _ImageInfo]:
@@ -423,44 +444,53 @@ class Image:
 
         # make sure the snapshot exist in all required regions
         snapshot_ids: Dict[str, str] = self._snapshot.copy(
-            self.snapshot_name, self._s3.bucket_region, self.image_regions
+            self.snapshot_name, self._s3.bucket_region, self.image_regions, self._allow_partial_region
         )
 
         images: Dict[str, _ImageInfo] = dict()
         missing_regions: List[str] = []
         for region in self.image_regions:
-            ec2client_region: EC2Client = boto3.client("ec2", region_name=region)
-            image_info: Optional[_ImageInfo] = self._get(ec2client_region)
-            if image_info:
-                if image_info.snapshot_id != snapshot_ids[region]:
-                    logger.warning(
-                        f"image with name '{self.image_name}' already exists ({image_info.image_id}) "
-                        f"in region {ec2client_region.meta.region_name} but the root device "
-                        f"snapshot id is unexpected (got {image_info.snapshot_id} but expected {snapshot_ids[region]})"
-                    )
+            if region not in snapshot_ids:
+                missing_regions.append(region)
+                continue
+            try:
+                ec2client_region: EC2Client = boto3.client("ec2", region_name=region)
+                image_info: Optional[_ImageInfo] = self._get(ec2client_region)
+                if image_info:
+                    if image_info.snapshot_id != snapshot_ids[region]:
+                        logger.warning(
+                            f"image with name '{self.image_name}' already exists ({image_info.image_id}) "
+                            f"in region {ec2client_region.meta.region_name} but the root device "
+                            f"snapshot id is unexpected (got {image_info.snapshot_id} but expected {snapshot_ids[region]})"
+                        )
+                    else:
+                        logger.info(
+                            f"image with name '{self.image_name}' already exists ({image_info.image_id}) "
+                            f"in region {ec2client_region.meta.region_name}"
+                        )
+                    images[region] = image_info
                 else:
-                    logger.info(
-                        f"image with name '{self.image_name}' already exists ({image_info.image_id}) "
-                        f"in region {ec2client_region.meta.region_name}"
-                    )
-                images[region] = image_info
-            else:
-                if image := self._register_image(snapshot_ids[region], ec2client_region):
-                    images[region] = image
-                else:
-                    missing_regions.append(region)
+                    if image := self._register_image(snapshot_ids[region], ec2client_region):
+                        images[region] = image
+                    else:
+                        missing_regions.append(region)
+            except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as exc:
+                _maybe_continue_on_region_error(self._allow_partial_region, region, exc)
         # wait for the images
         logger.info(f"Waiting for {len(images)} images to be ready the regions ...")
         for region, image_info in images.items():
-            ec2client_region_wait: EC2Client = boto3.client("ec2", region_name=region)
-            logger.info(
-                f"Waiting for {image_info.image_id} in {ec2client_region_wait.meta.region_name} "
-                "to exist/be available ..."
-            )
-            waiter_exists = ec2client_region_wait.get_waiter("image_exists")
-            waiter_exists.wait(ImageIds=[image_info.image_id])
-            waiter_available = ec2client_region_wait.get_waiter("image_available")
-            waiter_available.wait(ImageIds=[image_info.image_id])
+            try:
+                ec2client_region_wait: EC2Client = boto3.client("ec2", region_name=region)
+                logger.info(
+                    f"Waiting for {image_info.image_id} in {ec2client_region_wait.meta.region_name} "
+                    "to exist/be available ..."
+                )
+                waiter_exists = ec2client_region_wait.get_waiter("image_exists")
+                waiter_exists.wait(ImageIds=[image_info.image_id])
+                waiter_available = ec2client_region_wait.get_waiter("image_available")
+                waiter_available.wait(ImageIds=[image_info.image_id])
+            except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as exc:
+                _maybe_continue_on_region_error(self._allow_partial_region, region, exc)
         logger.info(f"{len(images)} images are ready")
 
         # share
@@ -468,8 +498,14 @@ class Image:
             self._share(self.conf["share"], images)
 
         if missing_regions:
-            logger.error("Failed to publish images to all regions", extra={"missing_regions": missing_regions})
-            raise exceptions.IncompleteImageSetException("Incomplete image set published")
+            if self._allow_partial_region:
+                logger.warning(
+                    f"Incomplete publish: missing regions {missing_regions} "
+                    f"— continuing because allow-partial-region set"
+                )
+            else:
+                logger.error("Failed to publish images to all regions", extra={"missing_regions": missing_regions})
+                raise exceptions.IncompleteImageSetException("Incomplete image set published")
 
         return images
 
@@ -571,15 +607,19 @@ class Image:
             if partition == "aws":
                 logger.info(f"marketplace version request for {self.image_name}")
                 # image needs to be in us-east-1
-                ec2client: EC2Client = boto3.client("ec2", region_name="us-east-1")
-                image_info: Optional[_ImageInfo] = self._get(ec2client)
-                if image_info:
-                    im = ImageMarketplace(self._ctx, self.image_name)
-                    im.request_new_version(image_info.image_id)
-                else:
-                    logger.error(
-                        f"can not request marketplace version for {self.image_name} because no image found in us-east-1"
-                    )
+                try:
+                    ec2client: EC2Client = boto3.client("ec2", region_name="us-east-1")
+                    image_info: Optional[_ImageInfo] = self._get(ec2client)
+                    if image_info:
+                        im = ImageMarketplace(self._ctx, self.image_name)
+                        im.request_new_version(image_info.image_id)
+                    else:
+                        logger.error(
+                            f"can not request marketplace version for {self.image_name}"
+                            f"because no image found in us-east-1"
+                        )
+                except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as exc:
+                    _maybe_continue_on_region_error(self._allow_partial_region, "us-east-1", exc)
             else:
                 logger.info(
                     f"found marketplace config for {self.image_name} and partition 'aws' but "

--- a/awspub/snapshot.py
+++ b/awspub/snapshot.py
@@ -2,9 +2,11 @@ import logging
 from typing import Dict, List, Optional
 
 import boto3
+import botocore.exceptions
 from mypy_boto3_ec2.client import EC2Client
 
 from awspub import exceptions
+from awspub.common import _maybe_continue_on_region_error
 from awspub.context import Context
 
 logger = logging.getLogger(__name__)
@@ -214,7 +216,13 @@ class Snapshot:
         # note: we don't wait for the snapshot to complete here!
         return resp["SnapshotId"]
 
-    def copy(self, snapshot_name: str, source_region: str, destination_regions: List[str]) -> Dict[str, str]:
+    def copy(
+        self,
+        snapshot_name: str,
+        source_region: str,
+        destination_regions: List[str],
+        allow_partial_region: bool = False,
+    ) -> Dict[str, str]:
         """
         Copy a snapshot to multiple regions
 
@@ -224,18 +232,31 @@ class Snapshot:
         :type source_region: str
         :param destination_regions: a list of regions to copy the snaphot to
         :type destionation_regions: List[str]
+        :param allow_partial_region: if True, log a warning and skip failed regions instead of raising
+        :type allow_partial_region: bool
         :return: a dict with region/snapshot-id mapping for the newly copied snapshots
         :rtype: Dict[str, str] where the key is a region name and the value a snapshot-id
         """
         snapshot_ids: Dict[str, str] = dict()
         for destination_region in destination_regions:
-            snapshot_ids[destination_region] = self._copy(snapshot_name, source_region, destination_region)
+            try:
+                snapshot_ids[destination_region] = self._copy(snapshot_name, source_region, destination_region)
+            except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as exc:
+                _maybe_continue_on_region_error(allow_partial_region, destination_region, exc)
 
         logger.info(f"Waiting for {len(snapshot_ids)} snapshots to appear in the destination regions ...")
+        failed_regions: List[str] = []
         for destination_region, snapshot_id in snapshot_ids.items():
-            ec2client_dest = boto3.client("ec2", region_name=destination_region)
-            waiter = ec2client_dest.get_waiter("snapshot_completed")
-            logger.info(f"Waiting for {snapshot_id} in {ec2client_dest.meta.region_name} to complete ...")
-            waiter.wait(SnapshotIds=[snapshot_id], WaiterConfig={"Delay": 30, "MaxAttempts": 90})
+            try:
+                ec2client_dest = boto3.client("ec2", region_name=destination_region)
+                waiter = ec2client_dest.get_waiter("snapshot_completed")
+                logger.info(f"Waiting for {snapshot_id} in {ec2client_dest.meta.region_name} to complete ...")
+                waiter.wait(SnapshotIds=[snapshot_id], WaiterConfig={"Delay": 30, "MaxAttempts": 90})
+            except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as exc:
+                _maybe_continue_on_region_error(allow_partial_region, destination_region, exc)
+                failed_regions.append(destination_region)
+
+        for region in failed_regions:
+            snapshot_ids.pop(region)
 
         return snapshot_ids

--- a/awspub/tests/test_common.py
+++ b/awspub/tests/test_common.py
@@ -2,7 +2,11 @@ from unittest.mock import patch
 
 import pytest
 
-from awspub.common import _get_regions, _split_partition
+from awspub.common import (
+    _get_regions,
+    _maybe_continue_on_region_error,
+    _split_partition,
+)
 
 
 @pytest.mark.parametrize(
@@ -56,3 +60,19 @@ def test_common__get_regions(regions_in_partition, configured_regions, expected_
         instance.describe_regions.return_value = {"Regions": [{"RegionName": r} for r in regions_in_partition]}
 
         assert _get_regions("", configured_regions) == expected_output
+
+
+@pytest.mark.parametrize(
+    "allow_partial_region,should_raise",
+    [
+        (False, True),
+        (True, False),
+    ],
+)
+def test_common__maybe_continue_on_region_error(allow_partial_region, should_raise):
+    exc = Exception("some error")
+    if should_raise:
+        with pytest.raises(Exception, match="some error"):
+            _maybe_continue_on_region_error(allow_partial_region, "us-east-1", exc)
+    else:
+        _maybe_continue_on_region_error(allow_partial_region, "us-east-1", exc)

--- a/awspub/tests/test_image.py
+++ b/awspub/tests/test_image.py
@@ -527,3 +527,77 @@ def test_register_image__should_raise_on_unhandled_client_error():
     snapshot_ids = {"eu-central-1": "my-snapshot"}
     with pytest.raises(botocore.exceptions.ClientError):
         img._register_image(snapshot_ids["eu-central-1"], instance) is None
+
+
+@patch("awspub.s3.S3.bucket_region", return_value="region1")
+def test_list_allow_partial_region(s3_bucket_mock):
+    """
+    Test that list() skips a failing region and returns partial
+    results when allow_partial_region is set
+    """
+    with patch("boto3.client"):
+        ctx = context.Context(curdir / "fixtures/config1.yaml", None)
+        ctx.allow_partial_region = True
+        img = image.Image(ctx, "test-image-6")
+        img._image_regions = ["region1", "region2"]
+        img._image_regions_cached = True
+        client_error = botocore.exceptions.ClientError({"Error": {"Code": "InternalError", "Message": "test"}}, "test")
+        with patch.object(img, "_get") as get_mock:
+            get_mock.side_effect = [client_error, image._ImageInfo("ami-123", "snap-123")]
+            result = img.list()
+        assert result == {"region2": image._ImageInfo("ami-123", "snap-123")}
+
+
+@patch("awspub.s3.S3.bucket_region", return_value="region1")
+def test_list_no_allow_partial_region(s3_bucket_mock):
+    """
+    Test that list() raises when allow_partial_region is not set and a ClientError occurs
+    """
+    with patch("boto3.client"):
+        ctx = context.Context(curdir / "fixtures/config1.yaml", None)
+        img = image.Image(ctx, "test-image-6")
+        img._image_regions = ["region1", "region2"]
+        img._image_regions_cached = True
+        client_error = botocore.exceptions.ClientError({"Error": {"Code": "InternalError", "Message": "test"}}, "test")
+        with patch.object(img, "_get") as get_mock:
+            get_mock.side_effect = [client_error, image._ImageInfo("ami-123", "snap-123")]
+            with pytest.raises(botocore.exceptions.ClientError):
+                img.list()
+
+
+@patch("awspub.s3.S3.bucket_region", return_value="region1")
+def test_create_allow_partial_region(s3_bucket_mock):
+    """
+    Test that create() skips a failing region and doesn't raise when allow_partial_region is set
+    """
+    with patch("boto3.client"):
+        ctx = context.Context(curdir / "fixtures/config1.yaml", None)
+        ctx.allow_partial_region = True
+        img = image.Image(ctx, "test-image-6")
+        img._image_regions = ["region1", "region2"]
+        img._image_regions_cached = True
+        client_error = botocore.exceptions.ClientError({"Error": {"Code": "InternalError", "Message": "test"}}, "test")
+        with patch.object(img, "_get") as get_mock, patch.object(img._snapshot, "copy") as copy_mock:
+            copy_mock.return_value = {"region1": "snapshot0", "region2": "snapshot1"}
+            get_mock.side_effect = [client_error, image._ImageInfo("ami-123", "snapshot1")]
+            result = img.create()
+        assert "region1" not in result
+        assert result.get("region2") == image._ImageInfo("ami-123", "snapshot1")
+
+
+@patch("awspub.s3.S3.bucket_region", return_value="region1")
+def test_create_no_allow_partial_region(s3_bucket_mock):
+    """
+    Test that create() raises when allow_partial_region is not set and a ClientError occurs
+    """
+    with patch("boto3.client"):
+        ctx = context.Context(curdir / "fixtures/config1.yaml", None)
+        img = image.Image(ctx, "test-image-6")
+        img._image_regions = ["region1", "region2"]
+        img._image_regions_cached = True
+        client_error = botocore.exceptions.ClientError({"Error": {"Code": "InternalError", "Message": "test"}}, "test")
+        with patch.object(img, "_get") as get_mock, patch.object(img._snapshot, "copy") as copy_mock:
+            copy_mock.return_value = {"region1": "snapshot0", "region2": "snapshot1"}
+            get_mock.side_effect = [client_error, image._ImageInfo("ami-123", "snapshot1")]
+            with pytest.raises(botocore.exceptions.ClientError):
+                img.create()

--- a/awspub/tests/test_snapshot.py
+++ b/awspub/tests/test_snapshot.py
@@ -1,6 +1,7 @@
 import pathlib
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+import botocore.exceptions
 import pytest
 
 from awspub import context, snapshot
@@ -120,3 +121,86 @@ def test_snapshot__get_import_snapshot_task_active():
         s._get_import_snapshot_task(client_mock, "021abb3f2338b5e57b5d870816565429659bc70769d71c486234ad60fe6aec67")
         == "import-snap-08b79d7b5d382d56b"
     )
+
+
+def test_snapshot_copy_success():
+    """
+    copy() succeeds for all destination regions — returns region→snapshot_id mapping
+    """
+    ctx = context.Context(curdir / "fixtures/config1.yaml", None)
+    s = snapshot.Snapshot(ctx)
+
+    waiter_mock = MagicMock()
+    ec2client_mock = MagicMock()
+    ec2client_mock.get_waiter.return_value = waiter_mock
+
+    with patch.object(s, "_copy", return_value="snap-abc") as copy_mock, patch(
+        "boto3.client", return_value=ec2client_mock
+    ):
+        result = s.copy("snap-name", "us-east-1", ["eu-west-1", "ap-southeast-1"])
+
+    assert result == {"eu-west-1": "snap-abc", "ap-southeast-1": "snap-abc"}
+    assert copy_mock.call_count == 2
+    waiter_mock.wait.assert_called()
+
+
+def test_snapshot_copy_region_error_raises():
+    """
+    copy() with allow_partial_region=False raises when _copy() fails for a region
+    """
+    ctx = context.Context(curdir / "fixtures/config1.yaml", None)
+    s = snapshot.Snapshot(ctx)
+
+    exc = botocore.exceptions.ClientError(
+        {"Error": {"Code": "RequestLimitExceeded", "Message": "throttled"}}, "CopySnapshot"
+    )
+
+    with patch.object(s, "_copy", side_effect=exc), patch("boto3.client", return_value=MagicMock()):
+        with pytest.raises(botocore.exceptions.ClientError):
+            s.copy("snap-name", "us-east-1", ["eu-west-1"], allow_partial_region=False)
+
+
+def test_snapshot_copy_region_error_partial_allowed():
+    """
+    copy() with allow_partial_region=True skips failed regions and returns only successful ones
+    """
+    ctx = context.Context(curdir / "fixtures/config1.yaml", None)
+    s = snapshot.Snapshot(ctx)
+
+    exc = botocore.exceptions.ClientError(
+        {"Error": {"Code": "RequestLimitExceeded", "Message": "throttled"}}, "CopySnapshot"
+    )
+
+    def copy_side_effect(snap_name, src, dst):
+        if dst == "me-central-1":
+            raise exc
+        return "snap-abc"
+
+    waiter_mock = MagicMock()
+    ec2client_mock = MagicMock()
+    ec2client_mock.get_waiter.return_value = waiter_mock
+
+    with patch.object(s, "_copy", side_effect=copy_side_effect), patch("boto3.client", return_value=ec2client_mock):
+        result = s.copy("snap-name", "us-east-1", ["eu-west-1", "me-central-1"], allow_partial_region=True)
+
+    assert result == {"eu-west-1": "snap-abc"}
+
+
+def test_snapshot_copy_waiter_error_partial_allowed():
+    """
+    copy() with allow_partial_region=True skips regions where the waiter fails
+    """
+    ctx = context.Context(curdir / "fixtures/config1.yaml", None)
+    s = snapshot.Snapshot(ctx)
+
+    exc = botocore.exceptions.WaiterError("snapshot_completed", "failed", None)
+
+    waiter_mock = MagicMock()
+    waiter_mock.wait.side_effect = exc
+    ec2client_mock = MagicMock()
+    ec2client_mock.get_waiter.return_value = waiter_mock
+
+    with patch.object(s, "_copy", return_value="snap-abc"), patch("boto3.client", return_value=ec2client_mock):
+        result = s.copy("snap-name", "us-east-1", ["eu-west-1"], allow_partial_region=True)
+
+    assert result == {}


### PR DESCRIPTION
There was an incident where services in the Middle East regions were completely unavailable for several days. This caused some API requests to fail when operating across all regions (e.g., creating images in all regions).

To handle similar situations in the future, add support for the `--allow-partial-regions` flag so users can continue making API requests even if some regions are unavailable.

When this flag is enabled, the service will not raise an error, as the goal is to keep the service running even if some regions are experiencing issues. But it will log in the output.


Tested:
```
2026-03-05 17:16:18,958:awspub.snapshot:INFO:Waiting for snap-xxx in me-central-1 to complete ...
2026-03-05 17:16:51,708:awspub.image:INFO:creating image with name 'test' in region me-south-1 ...
2026-03-05 17:16:52,852:awspub.image:INFO:image with name 'test' already exists (ami-xxx) in region us-east-1
2026-03-05 17:16:54,154:awspub.image:INFO:creating image with name 'test' in region me-central-1 ...
2026-03-05 17:18:04,103:awspub.image:WARNING:API request failed in region me-central-1: An error occurred (InternalError) when calling the RegisterImage operation (reached max retries: 4): An internal error has occurred — continuing because allow-partial-regions set
2026-03-05 17:18:04,103:awspub.image:INFO:Waiting for 2 images to be ready the regions ...
2026-03-05 17:18:04,110:awspub.image:INFO:Waiting for ami-xxx in me-south-1 to exist/be available ...
2026-03-05 17:18:05,434:awspub.image:INFO:Waiting for ami-xxx in us-east-1 to exist/be available ...
2026-03-05 17:18:05,858:awspub.image:INFO:2 images are ready
```