### PR TITLE
fix(ci): run apt-get update before installing packages in Sphinx venv workflow

### DIFF
--- a/.github/workflows/sphinx-python-dependency-build-checks.yml
+++ b/.github/workflows/sphinx-python-dependency-build-checks.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Install dependencies
         run: |
           set -ex
+          sudo apt-get update
           sudo apt -y install \
             cargo \
             libpython3-dev \


### PR DESCRIPTION
The Sphinx venv build check has been failing since mid-March because the
runner's apt package index references rustc/cargo .deb files that have
since been removed from the Ubuntu archive (404 errors).

Adding `apt-get update` before `apt install` refreshes the index.