### PR TITLE
feat: add regions_denylist to exclude regions from publication

### DIFF
--- a/awspub/common.py
+++ b/awspub/common.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import boto3
 from mypy_boto3_ec2.client import EC2Client
@@ -31,20 +31,25 @@ def _split_partition(val: str) -> Tuple[str, str]:
     return "aws", val
 
 
-def _get_regions(region_to_query: str, regions_allowlist: List[str]) -> List[str]:
+def _get_regions(
+    region_to_query: str, regions_allowlist: List[str], regions_denylist: Optional[List[str]] = None
+) -> List[str]:
     """
     Get a list of region names querying the `region_to_query` for all regions and
-    then filtering by `regions_allowlist`.
+    then filtering by `regions_allowlist` and `regions_denylist`.
     If no `regions_allowlist` is given, all queried regions are returned for the
     current partition.
     If `regions_allowlist` is given, all regions from that list are returned if
     the listed region exist in the current partition.
+    If `regions_denylist` is given, those regions are filtered out from the result.
     Eg. `us-east-1` listed in `regions_allowlist` won't be returned if the current
     partition is `aws-cn`.
     :param region_to_query: region name of current partition
     :type region_to_query: str
-    :praram regions_allowlist: list of regions in config file
+    :param regions_allowlist: list of regions in config file
     :type regions_allowlist: List[str]
+    :param regions_denylist: optional list of regions to exclude
+    :type regions_denylist: Optional[List[str]]
     :return: list of regions names
     :rtype: List[str]
     """
@@ -67,5 +72,12 @@ def _get_regions(region_to_query: str, regions_allowlist: List[str]) -> List[str
             )
     else:
         regions = ec2_regions_all
+
+    if regions_denylist:
+        exclude_set = set(regions_denylist)
+        regions = [r for r in regions if r not in exclude_set]
+        excluded_in_partition = exclude_set & set(ec2_regions_all)
+        if excluded_in_partition:
+            logger.info(f"regions {sorted(excluded_in_partition)} excluded from region selection")
 
     return regions

--- a/awspub/configmodels.py
+++ b/awspub/configmodels.py
@@ -3,7 +3,7 @@ import re
 from enum import Enum
 from typing import Dict, List, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from awspub.common import _split_partition
 
@@ -119,15 +119,31 @@ class ConfigImageSNSNotificationModel(BaseModel):
         "used partition, it will be ignored.",
         default=None,
     )
+    regions_denylist: Optional[List[str]] = Field(
+        description="Optional list of regions to exclude from sending notifications. "
+        "A region listed in both 'regions' and 'regions_denylist' will raise a validation error.",
+        default=None,
+    )
 
     @field_validator("message")
     def check_message(cls, value):
         # Check message protocols have default key
-        # Message should contain at least a top-level JSON key of “default”
+        # Message should contain at least a top-level JSON key of "default"
         # with a value that is a string
         if SNSNotificationProtocol.DEFAULT not in value:
             raise ValueError(f"{SNSNotificationProtocol.DEFAULT.value} key is required to send SNS notification")
         return value
+
+    @model_validator(mode="after")
+    def check_regions_denylist(self):
+        if self.regions and self.regions_denylist:
+            overlap = set(self.regions) & set(self.regions_denylist)
+            if overlap:
+                raise ValueError(
+                    f"Regions {sorted(overlap)} appear in both 'regions' and 'regions_denylist'. "
+                    "A region cannot be both included and excluded."
+                )
+        return self
 
 
 class ConfigImageModel(BaseModel):
@@ -142,6 +158,11 @@ class ConfigImageModel(BaseModel):
         description="Optional list of regions for this image. If not given, all available regions will"
         "be used from the currently used partition. If a region doesn't exist in the currently used partition,"
         " it will be ignored.",
+        default=None,
+    )
+    regions_denylist: Optional[List[str]] = Field(
+        description="Optional list of regions to exclude from publication for this image. "
+        "A region listed in both 'regions' and 'regions_denylist' will raise a validation error.",
         default=None,
     )
     separate_snapshot: bool = Field(description="Use a separate snapshot for this image?", default=False)
@@ -216,6 +237,17 @@ class ConfigImageModel(BaseModel):
                 if partition not in ["aws", "aws-cn", "aws-us-gov"]:
                     raise ValueError("Partition must be one of 'aws', 'aws-cn', 'aws-us-gov'")
         return v
+
+    @model_validator(mode="after")
+    def check_regions_denylist(self):
+        if self.regions and self.regions_denylist:
+            overlap = set(self.regions) & set(self.regions_denylist)
+            if overlap:
+                raise ValueError(
+                    f"Regions {sorted(overlap)} appear in both 'regions' and 'regions_denylist'. "
+                    "A region cannot be both included and excluded."
+                )
+        return self
 
 
 class ConfigModel(BaseModel):

--- a/awspub/image.py
+++ b/awspub/image.py
@@ -126,7 +126,9 @@ class Image:
         """
         if not self._image_regions_cached:
             regions_configured = self.conf["regions"] if "regions" in self.conf else []
-            self._image_regions = _get_regions(self._s3.bucket_region, regions_configured)
+            regions_configured = self.conf.get("regions") or []
+            regions_denylist = self.conf["regions_denylist"] if "regions_denylist" in self.conf else None
+            self._image_regions = _get_regions(self._s3.bucket_region, regions_configured, regions_denylist)
             self._image_regions_cached = True
         return self._image_regions
 

--- a/awspub/sns.py
+++ b/awspub/sns.py
@@ -50,7 +50,10 @@ class SNSNotification(object):
         """
 
         regions_configured = topic_config["regions"] if "regions" in topic_config else []
-        sns_regions = _get_regions(self._s3.bucket_region, regions_configured)
+        if regions_configured is None:
+            regions_configured = []
+        regions_denylist = topic_config["regions_denylist"] if "regions_denylist" in topic_config else None
+        sns_regions = _get_regions(self._s3.bucket_region, regions_configured, regions_denylist)
 
         return sns_regions
 

--- a/awspub/tests/fixtures/config-invalid-regions-denylist-sns.yaml
+++ b/awspub/tests/fixtures/config-invalid-regions-denylist-sns.yaml
@@ -1,0 +1,29 @@
+awspub:
+  s3:
+    bucket_name: "bucket1"
+
+  source:
+    path: "config1.vmdk"
+    architecture: "x86_64"
+
+  images:
+    "test-image-1":
+      description: |
+        A test image with overlapping include and exclude regions for SNS
+      boot_mode: "uefi"
+      regions:
+        - "eu-central-1"
+        - "us-east-1"
+      sns:
+        - "topic1":
+            subject: "topic1-subject"
+            message:
+              default: "default-message"
+            regions:
+              - "eu-central-1"
+              - "us-east-1"
+            regions_denylist:
+              - "us-east-1"
+
+  tags:
+    name: "foobar"

--- a/awspub/tests/fixtures/config-invalid-regions-denylist.yaml
+++ b/awspub/tests/fixtures/config-invalid-regions-denylist.yaml
@@ -1,0 +1,22 @@
+awspub:
+  s3:
+    bucket_name: "bucket1"
+
+  source:
+    path: "config1.vmdk"
+    architecture: "x86_64"
+
+  images:
+    "test-image-1":
+      description: |
+        A test image with overlapping include and exclude regions
+      boot_mode: "uefi"
+      regions:
+        - "eu-central-1"
+        - "us-east-1"
+      regions_denylist:
+        - "us-east-1"
+      temporary: true
+
+  tags:
+    name: "foobar"

--- a/awspub/tests/fixtures/config-regions-denylist.yaml
+++ b/awspub/tests/fixtures/config-regions-denylist.yaml
@@ -1,0 +1,45 @@
+awspub:
+  s3:
+    bucket_name: "bucket1"
+
+  source:
+    path: "config1.vmdk"
+    architecture: "x86_64"
+
+  images:
+    "test-image-1":
+      description: |
+        A test image with regions_denylist
+      boot_mode: "uefi"
+      regions:
+        - "eu-central-1"
+        - "ap-southeast-1"
+      regions_denylist:
+        - "us-east-1"
+      temporary: true
+
+    "test-image-2":
+      description: |
+        A test image excluding regions from all available
+      boot_mode: "uefi"
+      regions_denylist:
+        - "us-east-1"
+      temporary: true
+
+    "test-image-3":
+      description: |
+        A test image with regions_denylist for sns
+      boot_mode: "uefi"
+      regions:
+        - "eu-central-1"
+        - "us-east-1"
+      sns:
+        - "topic1":
+            subject: "topic1-subject"
+            message:
+              default: "default-message"
+            regions_denylist:
+              - "us-east-1"
+
+  tags:
+    name: "foobar"

--- a/awspub/tests/test_common.py
+++ b/awspub/tests/test_common.py
@@ -43,16 +43,26 @@ def test_common__split_partition(input, expected_output):
 
 
 @pytest.mark.parametrize(
-    "regions_in_partition,configured_regions,expected_output",
+    "regions_in_partition,configured_regions,regions_denylist,expected_output",
     [
-        (["region-1", "region-2"], ["region-1", "region-3"], ["region-1"]),
-        (["region-1", "region-2", "region-3"], ["region-4", "region-5"], []),
-        (["region-1", "region-2"], [], ["region-1", "region-2"]),
+        (["region-1", "region-2"], ["region-1", "region-3"], None, ["region-1"]),
+        (["region-1", "region-2", "region-3"], ["region-4", "region-5"], None, []),
+        (["region-1", "region-2"], [], None, ["region-1", "region-2"]),
+        # exclude regions from allowlist
+        (["region-1", "region-2"], ["region-1", "region-2"], ["region-1"], ["region-2"]),
+        # exclude from all available regions (no allowlist)
+        (["region-1", "region-2", "region-3"], [], ["region-1", "region-3"], ["region-2"]),
+        # exclude region not in allowlist - no effect
+        (["region-1", "region-2"], ["region-1"], ["region-3"], ["region-1"]),
+        # exclude all regions
+        (["region-1", "region-2"], ["region-1"], ["region-1"], []),
+        # exclude from all available
+        (["region-1"], [], ["region-1"], []),
     ],
 )
-def test_common__get_regions(regions_in_partition, configured_regions, expected_output):
+def test_common__get_regions(regions_in_partition, configured_regions, regions_denylist, expected_output):
     with patch("boto3.client") as bclient_mock:
         instance = bclient_mock.return_value
         instance.describe_regions.return_value = {"Regions": [{"RegionName": r} for r in regions_in_partition]}
 
-        assert _get_regions("", configured_regions) == expected_output
+        assert _get_regions("", configured_regions, regions_denylist) == expected_output

--- a/awspub/tests/test_context.py
+++ b/awspub/tests/test_context.py
@@ -86,3 +86,30 @@ def test_invalid_configuration_extra_field():
     """
     with pytest.raises(ValidationError):
         context.Context(curdir / "fixtures/config-invalid-s3-extra.yaml", None)
+
+
+def test_context_with_regions_denylist():
+    """
+    Create a Context object with regions_denylist configured
+    """
+    ctx = context.Context(curdir / "fixtures/config-regions-denylist.yaml", None)
+    assert ctx.conf["images"]["test-image-1"]["regions_denylist"] == ["us-east-1"]
+    assert ctx.conf["images"]["test-image-1"]["regions"] == ["eu-central-1", "ap-southeast-1"]
+
+
+def test_context_with_overlapping_regions_denylist():
+    """
+    Create a Context object with overlapping include and exclude regions - should fail validation
+    """
+    with pytest.raises(ValidationError) as exc_info:
+        context.Context(curdir / "fixtures/config-invalid-regions-denylist.yaml", None)
+    assert "appear in both 'regions' and 'regions_denylist'" in str(exc_info.value)
+
+
+def test_context_with_overlapping_regions_denylist_sns():
+    """
+    Create a Context object with overlapping include and exclude regions for SNS - should fail validation
+    """
+    with pytest.raises(ValidationError) as exc_info:
+        context.Context(curdir / "fixtures/config-invalid-regions-denylist-sns.yaml", None)
+    assert "appear in both 'regions' and 'regions_denylist'" in str(exc_info.value)

--- a/awspub/tests/test_image.py
+++ b/awspub/tests/test_image.py
@@ -71,6 +71,49 @@ def test_image_regions(s3_region_mock, imagename, regions_in_partition, regions_
         assert sorted(img.image_regions) == sorted(regions_expected)
 
 
+@patch("awspub.s3.S3.bucket_region", return_value="eu-central-1")
+def test_image_regions_with_denylist(s3_region_mock):
+    """
+    Test the regions for a given image with regions_denylist
+    """
+    with patch("boto3.client") as bclient_mock:
+        instance = bclient_mock.return_value
+        instance.describe_regions.return_value = {
+            "Regions": [
+                {"RegionName": "eu-central-1"},
+                {"RegionName": "us-east-1"},
+                {"RegionName": "ap-southeast-1"},
+            ]
+        }
+        ctx = context.Context(curdir / "fixtures/config-regions-denylist.yaml", None)
+        ctx.conf["images"]["test-image-1"]["regions"] = [
+            "eu-central-1",
+            "us-east-1",
+            "ap-southeast-1",
+        ]
+        img = image.Image(ctx, "test-image-1")
+        assert sorted(img.image_regions) == sorted(["eu-central-1", "ap-southeast-1"])
+
+
+@patch("awspub.s3.S3.bucket_region", return_value="eu-central-1")
+def test_image_regions_denylist_from_all(s3_region_mock):
+    """
+    Test regions_denylist with no explicit regions list (excludes from all available)
+    """
+    with patch("boto3.client") as bclient_mock:
+        instance = bclient_mock.return_value
+        instance.describe_regions.return_value = {
+            "Regions": [
+                {"RegionName": "eu-central-1"},
+                {"RegionName": "us-east-1"},
+                {"RegionName": "ap-southeast-1"},
+            ]
+        }
+        ctx = context.Context(curdir / "fixtures/config-regions-denylist.yaml", None)
+        img = image.Image(ctx, "test-image-2")
+        assert sorted(img.image_regions) == sorted(["eu-central-1", "ap-southeast-1"])
+
+
 @pytest.mark.parametrize(
     "imagename,cleanup",
     [

--- a/docs/config-samples/config-regions-denylist.yaml
+++ b/docs/config-samples/config-regions-denylist.yaml
@@ -1,0 +1,22 @@
+---
+awspub:
+  source:
+    path: "image.vmdk"
+    architecture: "x86_64"
+
+  s3:
+    bucket_name: "awspub-toabctl"
+
+  images:
+    "my-custom-image":
+      boot_mode: "uefi-preferred"
+      regions_denylist:
+        - us-east-1
+      sns:
+        - "my-topic1":
+            subject: "my-topic1-subject"
+            message:
+              default: "This is default message"
+              email: "This is message for email protocols."
+            regions_denylist:
+              - eu-central-1

--- a/docs/how_to/publish.rst
+++ b/docs/how_to/publish.rst
@@ -241,6 +241,26 @@ Create the image and use the `publish` command to publish the image and also pus
   awspub create config.yaml --config-mapping config.yaml.mapping
   awspub publish config.yaml --config-mapping config.yaml.mapping
 
+Region filtering
+~~~~~~~~~~~~~~~~
+
+By default, images are published to all available regions in the current partition.
+Restricting regions can be done with the ``regions_denylist`` configuration option
+at both the image and SNS notification levels.
+
+.. literalinclude:: ../config-samples/config-regions-denylist.yaml
+   :language: yaml
+
+In the example above, the image ``my-custom-image`` will be published to all regions
+**except** ``us-east-1``. For SNS notifications, ``eu-central-1`` will be excluded
+from delivery. ``regions_denylist`` removes those regions from whichever set would
+otherwise be used (the explicit ``regions`` list, or all available regions if
+``regions`` is not specified).
+
+.. note::
+   A region listed in both ``regions`` and ``regions_denylist`` will cause a
+   validation error. Regions must not appear in both lists.
+
 SNS Notification
 ~~~~~~~~~~~~~~~~
 
@@ -261,7 +281,9 @@ Currently, the supported protocols are ``default`` and ``email`` only, and the `
 send notifications.
 The ``default`` message will be used as a fallback message for any protocols.
 
-Also, Regions can also be specified in ``sns`` configuration to indicate where the notification should be sent. If no regions are specified, SNS will default to using all regions in the partition.
+Regions can also be specified in ``sns`` configuration to indicate where the notification should be sent.
+If no regions are specified, SNS will default to using all regions in the partition.
+Additionally, ``regions_denylist`` can be used to exclude specific regions from SNS notification delivery.
 
 Create the image and use the `publish` command to publish the image and also notify the published images to users:
 


### PR DESCRIPTION
The change introduces a regions_denylist configuration option at the image and SNS notification levels, enabling users to explicitly exclude specific regions from publication

---

Tried this with the following config and it correctly only published to us-east-1 and us-east-2
```yaml
      regions_denylist:
        - us-west-1
        - us-west-2
        - af-south-1
        - ap-east-1
        - ap-south-2
        - ap-southeast-3
        - ap-southeast-5
        - ap-southeast-4
        - ap-south-1
        - ap-southeast-6
        - ap-northeast-3
        - ap-northeast-2
        - ap-southeast-1
        - ap-southeast-2
        - ap-east-2
        - ap-southeast-7
        - ap-northeast-1
        - ca-central-1
        - ca-west-1
        - eu-central-1
        - eu-west-1
        - eu-west-2
        - eu-south-1
        - eu-west-3
        - eu-south-2
        - eu-north-1
        - eu-central-2
        - il-central-1
        - mx-central-1
        - me-south-1
        - me-central-1
        - sa-east-1
```
